### PR TITLE
Rename `fetchval` to `fetch_value` for consistency.

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -39,7 +39,7 @@ class AsyncIOConnection(base_con.BaseConnection):
             False, False, self._codecs_registry, self._query_cache,
             query, args, kwargs)
 
-    async def fetchval(self, query, *args, **kwargs):
+    async def fetch_value(self, query, *args, **kwargs):
         return await self._protocol.execute_anonymous(
             True, False, self._codecs_registry, self._query_cache,
             query, args, kwargs)

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -33,7 +33,7 @@ class BlockingIOConnection(base_con.BaseConnection):
             False, False, self._codecs_registry, self._query_cache,
             query, args, kwargs)
 
-    def fetchval(self, query, *args, **kwargs):
+    def fetch_value(self, query, *args, **kwargs):
         return self._protocol.sync_execute_anonymous(
             True, False, self._codecs_registry, self._query_cache,
             query, args, kwargs)

--- a/tests/test_async_fetch.py
+++ b/tests/test_async_fetch.py
@@ -136,7 +136,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
         ''')
         self.assertEqual(r, [])
 
-        r = await self.con.fetchval('''
+        r = await self.con.fetch_value('''
             CREATE TYPE test::server_fetch_single_command_01 {
                 CREATE REQUIRED PROPERTY server_fetch_single_command_01 ->
                     std::str;
@@ -144,7 +144,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
         ''')
         self.assertIsNone(r)
 
-        r = await self.con.fetchval('''
+        r = await self.con.fetch_value('''
             DROP TYPE test::server_fetch_single_command_01;
         ''')
         self.assertIsNone(r)
@@ -174,12 +174,12 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
         ''')
         self.assertEqual(r, [])
 
-        r = await self.con.fetchval('''
+        r = await self.con.fetch_value('''
             SET MODULE default;
         ''')
         self.assertIsNone(r)
 
-        r = await self.con.fetchval('''
+        r = await self.con.fetch_value('''
             SET ALIAS foo AS MODULE default,
                 ALIAS bar AS MODULE std;
         ''')
@@ -217,7 +217,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
                 self.assertEqual(r, '[]')
 
         for q in qs:
-            r = await self.con.fetchval(q)
+            r = await self.con.fetch_value(q)
             self.assertIsNone(r)
 
     async def test_async_fetch_single_command_04(self):
@@ -230,7 +230,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
 
         with self.assertRaisesRegex(edgedb.ProtocolError,
                                     'expected one statement'):
-            await self.con.fetchval('''
+            await self.con.fetch_value('''
                 SELECT 1;
                 SET MODULE blah;
             ''')
@@ -245,7 +245,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
     async def test_async_basic_datatypes_01(self):
         for _ in range(10):
             self.assertEqual(
-                await self.con.fetchval(
+                await self.con.fetch_value(
                     'select ()'),
                 ())
 
@@ -255,7 +255,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
                 edgedb.Set([(1,)]))
 
             self.assertEqual(
-                await self.con.fetchval(
+                await self.con.fetch_value(
                     'select <array<int64>>[]'),
                 [])
 
@@ -276,10 +276,10 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
 
             with self.assertRaisesRegex(edgedb.InterfaceError,
                                         'the result set can be a multiset'):
-                await self.con.fetchval('SELECT {1, 2}')
+                await self.con.fetch_value('SELECT {1, 2}')
 
             self.assertIsNone(
-                await self.con.fetchval('SELECT <int64>{}'))
+                await self.con.fetch_value('SELECT <int64>{}'))
 
     async def test_async_basic_datatypes_02(self):
         self.assertEqual(

--- a/tests/test_sync_fetch.py
+++ b/tests/test_sync_fetch.py
@@ -133,7 +133,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         ''')
         self.assertEqual(r, [])
 
-        r = self.con.fetchval('''
+        r = self.con.fetch_value('''
             CREATE TYPE test::server_fetch_single_command_01 {
                 CREATE REQUIRED PROPERTY server_fetch_single_command_01 ->
                     std::str;
@@ -141,7 +141,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         ''')
         self.assertIsNone(r)
 
-        r = self.con.fetchval('''
+        r = self.con.fetch_value('''
             DROP TYPE test::server_fetch_single_command_01;
         ''')
         self.assertIsNone(r)
@@ -171,12 +171,12 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         ''')
         self.assertEqual(r, [])
 
-        r = self.con.fetchval('''
+        r = self.con.fetch_value('''
             SET MODULE default;
         ''')
         self.assertIsNone(r)
 
-        r = self.con.fetchval('''
+        r = self.con.fetch_value('''
             SET ALIAS foo AS MODULE default,
                 ALIAS bar AS MODULE std;
         ''')
@@ -214,7 +214,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
                 self.assertEqual(r, '[]')
 
         for q in qs:
-            r = self.con.fetchval(q)
+            r = self.con.fetch_value(q)
             self.assertIsNone(r)
 
     def test_sync_fetch_single_command_04(self):
@@ -227,7 +227,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
         with self.assertRaisesRegex(edgedb.ProtocolError,
                                     'expected one statement'):
-            self.con.fetchval('''
+            self.con.fetch_value('''
                 SELECT 1;
                 SET MODULE blah;
             ''')
@@ -242,7 +242,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
     def test_sync_basic_datatypes_01(self):
         for _ in range(10):
             self.assertEqual(
-                self.con.fetchval(
+                self.con.fetch_value(
                     'select ()'),
                 ())
 
@@ -252,7 +252,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
                 edgedb.Set([(1,)]))
 
             self.assertEqual(
-                self.con.fetchval(
+                self.con.fetch_value(
                     'select <array<int64>>[]'),
                 [])
 
@@ -273,10 +273,10 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
             with self.assertRaisesRegex(edgedb.InterfaceError,
                                         'the result set can be a multiset'):
-                self.con.fetchval('SELECT {1, 2}')
+                self.con.fetch_value('SELECT {1, 2}')
 
             self.assertIsNone(
-                self.con.fetchval('SELECT <int64>{}'))
+                self.con.fetch_value('SELECT <int64>{}'))
 
     def test_sync_basic_datatypes_02(self):
         self.assertEqual(


### PR DESCRIPTION
The new method name is more explicit and more consistent with
`fetch_json` naming scheme.