### PR TITLE
Fix decoding of array sets

### DIFF
--- a/edgedb/protocol/codecs/array.pxd
+++ b/edgedb/protocol/codecs/array.pxd
@@ -27,6 +27,8 @@ cdef class BaseArrayCodec(BaseCodec):
     cdef _set_collection_item(self, object collection, Py_ssize_t i,
                               object element)
 
+    cdef _decode_array(self, FRBuffer *buf)
+
 
 @cython.final
 cdef class ArrayCodec(BaseArrayCodec):

--- a/edgedb/protocol/codecs/array.pyx
+++ b/edgedb/protocol/codecs/array.pyx
@@ -78,13 +78,16 @@ cdef class BaseArrayCodec(BaseCodec):
         buf.write_buffer(elem_data)
 
     cdef decode(self, FRBuffer *buf):
+        return self._decode_array(buf)
+
+    cdef inline _decode_array(self, FRBuffer *buf):
         cdef:
-            object result
             Py_ssize_t elem_count
+            int32_t ndims = hton.unpack_int32(frb_read(buf, 4))
+            object result
             Py_ssize_t i
             int32_t elem_len
             FRBuffer elem_buf
-            int32_t ndims = hton.unpack_int32(frb_read(buf, 4))
 
         frb_read(buf, 4)  # ignore flags
 

--- a/edgedb/protocol/codecs/set.pxd
+++ b/edgedb/protocol/codecs/set.pxd
@@ -20,5 +20,7 @@
 @cython.final
 cdef class SetCodec(BaseArrayCodec):
 
+    cdef _decode_array_set(self, FRBuffer *buf)
+
     @staticmethod
     cdef BaseCodec new(bytes tid, BaseCodec sub_codec)

--- a/tests/test_async_fetch.py
+++ b/tests/test_async_fetch.py
@@ -330,6 +330,33 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
                 await self.con.fetch_json('SELECT <int64>{}'),
                 '[]')
 
+    async def test_async_basic_datatypes_04(self):
+        val = await self.con.fetch_value(
+            '''
+                SELECT schema::ObjectType {
+                    foo := {
+                        [(a := 1, b := 2), (a := 3, b := 4)],
+                        [(a := 5, b := 6)],
+                        <array <tuple<a: int64, b: int64>>>[],
+                    }
+                } LIMIT 1
+            '''
+        )
+
+        self.assertEqual(
+            val.foo,
+            edgedb.Set([
+                edgedb.Array([
+                    edgedb.NamedTuple(a=1, b=2),
+                    edgedb.NamedTuple(a=3, b=4),
+                ]),
+                edgedb.Array([
+                    edgedb.NamedTuple(a=5, b=6),
+                ]),
+                edgedb.Array([]),
+            ]),
+        )
+
     async def test_async_args_01(self):
         self.assertEqual(
             await self.con.fetch(


### PR DESCRIPTION
A Set of an array type is encoded as a two-dimensional array on the
wire, but the current Set codec implementation rejects such arrays
unconditionally.  Fix this.