### PR TITLE
protocol: Switch to length-prefixed bytes/text

### DIFF
--- a/edgedb/errors/_base.py
+++ b/edgedb/errors/_base.py
@@ -53,28 +53,34 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     @property
     def _position(self):
         # not a stable API method
-        return int(self._attrs.get('P', -1))
+        return int(self._read_str_field(FIELD_POSITION_START, -1))
 
     @property
     def _line(self):
         # not a stable API method
-        return int(self._attrs.get('L', -1))
+        return int(self._read_str_field(FIELD_LINE, -1))
 
     @property
     def _col(self):
         # not a stable API method
-        return int(self._attrs.get('C', -1))
+        return int(self._read_str_field(FIELD_COLUMN, -1))
 
     @property
     def _hint(self):
         # not a stable API method
-        return self._attrs.get('H')
+        return self._read_str_field(FIELD_HINT)
+
+    def _read_str_field(self, key, default=None):
+        val = self._attrs.get(key)
+        if val:
+            return val.decode('utf-8')
+        return default
 
     def get_code(self):
         return self._code
 
     def get_server_context(self):
-        return self._attrs.get('T')
+        return self._read_str_field(FIELD_SERVER_TRACEBACK)
 
     @staticmethod
     def _from_code(code, *args, **kwargs):
@@ -110,3 +116,14 @@ def _lookup_error_cls(code: int):
 
 def _decode(code: int):
     return tuple(code.to_bytes(4, 'big'))
+
+
+FIELD_HINT = 0x_00_01
+FIELD_DETAILS = 0x_00_02
+FIELD_SERVER_TRACEBACK = 0x_01_01
+
+# XXX: Subject to be changed/deprecated.
+FIELD_POSITION_START = 0x_FF_F1
+FIELD_POSITION_END = 0x_FF_F2
+FIELD_LINE = 0x_FF_F3
+FIELD_COLUMN = 0x_FF_F4

--- a/edgedb/protocol/codecs/base.pyx
+++ b/edgedb/protocol/codecs/base.pyx
@@ -144,7 +144,7 @@ cdef class BaseRecordCodec(BaseCodec):
                             e.args[0])) from None
 
         buf.write_int32(4 + elem_data.len())  # buffer length
-        buf.write_int32(objlen)
+        buf.write_int32(<int32_t><uint32_t>objlen)
         buf.write_buffer(elem_data)
 
 

--- a/edgedb/protocol/codecs/namedtuple.pyx
+++ b/edgedb/protocol/codecs/namedtuple.pyx
@@ -83,7 +83,7 @@ cdef class NamedTupleCodec(BaseNamedRecordCodec):
                         f'cannot encode {name!r} argument') from None
 
         buf.write_int32(4 + elem_data.len())  # buffer length
-        buf.write_int32(objlen)
+        buf.write_int32(<int32_t><uint32_t>objlen)
         buf.write_buffer(elem_data)
 
     @staticmethod

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -83,7 +83,7 @@ cdef class SansIOProtocol:
 
         TransactionStatus xact_status
 
-        object server_settings
+        dict server_settings
 
         readonly bytes last_status
         readonly bytes last_details
@@ -95,6 +95,8 @@ cdef class SansIOProtocol:
     cdef parse_command_complete_message(self)
     cdef parse_describe_type_message(self, CodecsRegistry reg)
     cdef amend_parse_error(self, exc, bint json_mode, bint expect_one)
+
+    cdef dict parse_headers(self)
     cdef parse_error_message(self)
 
     cdef write(self, WriteBuffer buf)


### PR DESCRIPTION
This makes the protocol framing more robust and extensible compared
to NULL-terminated strings.  Parsing length-prefixed strings is also
faster because there is no need to scan the buffer for NULL.