### PR TITLE
protocol: Add headers to all major messages

### DIFF
--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -96,7 +96,9 @@ cdef class SansIOProtocol:
     cdef parse_describe_type_message(self, CodecsRegistry reg)
     cdef amend_parse_error(self, exc, bint json_mode, bint expect_one)
 
+    cdef inline reject_headers(self)
     cdef dict parse_headers(self)
+
     cdef parse_error_message(self)
 
     cdef write(self, WriteBuffer buf)


### PR DESCRIPTION
As of right now we don't have any headers so all we do is send an
int16 0 in the beginning of each message.  In the future, however,
we'll be able to attach additional meta-information to messages
without breaking the protocol.