### PR TITLE
Enforce strict separation between timezone-aware and local date/time

### DIFF
--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -18,10 +18,13 @@
 
 
 cimport cython
+
 cimport cpython
+cimport cpython.datetime
 
 import asyncio
 import collections
+import datetime
 import json
 import time
 import types
@@ -59,6 +62,9 @@ from edgedb import scram
 include "./consts.pxi"
 include "./lru.pyx"
 include "./codecs/codecs.pyx"
+
+
+cpython.datetime.import_datetime()
 
 
 cdef class QueryCodecsCache:

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -31,7 +31,9 @@ class TestProto(tb.SyncQueryTestCase):
             with self.assertRaises(edgedb.ClientError):
                 # Python dattime.Date object can't represent this date, so
                 # we know that the codec will fail.
-                self.con.fetchall("SELECT <naive_date>'0001-01-01 BC';")
+                # The test will be rewritten once it's possible to override
+                # default codecs.
+                self.con.fetchall("SELECT <local_date>'0001-01-01 BC';")
 
             # The protocol, though, shouldn't be in some inconsistent
             # state; it should allow new queries to execute successfully.
@@ -44,8 +46,10 @@ class TestProto(tb.SyncQueryTestCase):
             with self.assertRaises(edgedb.ClientError):
                 # Python dattime.Date object can't represent this date, so
                 # we know that the codec will fail.
+                # The test will be rewritten once it's possible to override
+                # default codecs.
                 self.con.fetchall("""
-                    SELECT <naive_date>{
+                    SELECT <local_date>{
                         '2010-01-01',
                         '2010-01-02',
                         '2010-01-03',


### PR DESCRIPTION
It's no longer allowed to pass a timezone-aware datetime object as
a <local_datetime> parameters.  And vice-versa, a <datetime> parameter
cannot accept a naive datetime object.