### PR TITLE
Stop defaulting to a particular transaction isolation level

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -62,8 +62,7 @@ class AsyncIOConnection(base_con.BaseConnection):
     async def execute(self, query):
         await self._protocol.simple_query(query)
 
-    def transaction(self, *, isolation='read_committed', readonly=False,
-                    deferrable=False):
+    def transaction(self, *, isolation=None, readonly=None, deferrable=None):
         return transaction.AsyncTransaction(
             self, isolation, readonly, deferrable)
 

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -57,8 +57,7 @@ class BlockingIOConnection(base_con.BaseConnection):
     def execute(self, query):
         self._protocol.sync_simple_query(query)
 
-    def transaction(self, *, isolation='read_committed', readonly=False,
-                    deferrable=False):
+    def transaction(self, *, isolation=None, readonly=None, deferrable=None):
         return transaction.Transaction(
             self, isolation, readonly, deferrable)
 

--- a/edgedb/errors/__init__.py
+++ b/edgedb/errors/__init__.py
@@ -72,6 +72,8 @@ __all__ = _base.__all__ + (
     'CardinalityViolationError',
     'MissingRequiredError',
     'TransactionError',
+    'TransactionSerializationError',
+    'TransactionDeadlockError',
     'ConfigurationError',
     'AccessError',
     'AuthenticationError',
@@ -321,6 +323,14 @@ class MissingRequiredError(IntegrityError):
 
 class TransactionError(ExecutionError):
     _code = 0x_05_03_00_00
+
+
+class TransactionSerializationError(TransactionError):
+    _code = 0x_05_03_00_01
+
+
+class TransactionDeadlockError(TransactionError):
+    _code = 0x_05_03_00_02
 
 
 class ConfigurationError(EdgeDBError):


### PR DESCRIPTION
If a transaction isolation level is not specified, don't assume any
defaults and just generate a `START TRANSACTION` statement without an
explicit `ISOLATION LEVEL`.  This allows the connection and the server
to be free in their choice of the default.