### PR TITLE
Implement a new type: edgedb.Duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean:
 
 
 _touch:
+	rm -fr $(ROOT)/edgedb/datatypes/datatypes.c
 	find $(ROOT)/edgedb/protocol -name '*.pyx' | xargs touch
 	find $(ROOT)/edgedb/datatypes -name '*.pyx' | xargs touch
 	find $(ROOT)/edgedb/datatypes -name '*.c' | xargs touch

--- a/edgedb/datatypes/datatypes.pxd
+++ b/edgedb/datatypes/datatypes.pxd
@@ -17,9 +17,11 @@
 #
 
 
+cimport cython
 cimport cpython
 
 
+include "./duration.pxd"
 include "./enum.pxd"
 
 

--- a/edgedb/datatypes/datatypes.pyx
+++ b/edgedb/datatypes/datatypes.pyx
@@ -17,6 +17,10 @@
 #
 
 
+cimport cython
+cimport cpython
+
+include "./duration.pyx"
 include "./enum.pyx"
 
 

--- a/edgedb/datatypes/duration.pxd
+++ b/edgedb/datatypes/duration.pxd
@@ -1,7 +1,7 @@
 #
 # This source file is part of the EdgeDB open source project.
 #
-# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,16 @@
 #
 
 
-# flake8: noqa
-
-from .errors import *
-
-from edgedb.datatypes.datatypes import Tuple, NamedTuple, EnumValue
-from edgedb.datatypes.datatypes import Set, Object, Array, Link, LinkSet
-from edgedb.datatypes.datatypes import Duration
-
-from .asyncio_con import async_connect
-from .blocking_con import connect
+from libc.stdint cimport int64_t, int32_t
 
 
-__all__ = (
-    'async_connect', 'connect',
-    'EnumValue', 'Tuple', 'NamedTuple', 'Set',
-    'Object', 'Array', 'Link', 'LinkSet',
-) + errors.__all__
+@cython.final
+cdef class Duration:
+
+    cdef:
+        readonly int64_t microseconds
+        readonly int32_t days
+        readonly int32_t months
+
+
+cdef new_duration(int64_t microseconds, int32_t days, int32_t months)

--- a/edgedb/datatypes/duration.pyx
+++ b/edgedb/datatypes/duration.pyx
@@ -1,0 +1,135 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from libc.stdint cimport int64_t, int32_t
+
+
+DEF MONTHS_PER_YEAR         = 12
+DEF USECS_PER_HOUR          = 3600000000
+DEF USECS_PER_MINUTE        = 60000000
+DEF USECS_PER_SEC           = 1000000
+DEF MAX_INTERVAL_PRECISION  = 6
+
+
+@cython.final
+cdef class Duration:
+
+    def __init__(self, *, int microseconds=0, int days=0, int months=0):
+        self.microseconds = microseconds
+        self.days = days
+        self.months = months
+
+    def __eq__(self, other):
+        if type(other) is not Duration:
+            return NotImplemented
+
+        return (
+            self.microseconds == (<Duration>other).microseconds and
+            self.days == (<Duration>other).days and
+            self.months == (<Duration>other).months
+        )
+
+    def __hash__(self):
+        return hash((Duration, self.microseconds, self.days, self.months))
+
+    def __repr__(self):
+        return f'<edgedb.Duration "{self}">'
+
+    @cython.cdivision(True)
+    def __str__(self):
+        # This is closely modeled after interval_out().
+        cdef:
+            int64_t year = self.months / MONTHS_PER_YEAR
+            int64_t mon = self.months % MONTHS_PER_YEAR
+            int64_t time = self.microseconds
+            int64_t tfrac
+            int64_t hour
+            int64_t min
+            int64_t sec
+            int64_t fsec
+            list buf = []
+            bint neg
+            bint is_before = False
+            bint is_first = True
+
+        tfrac = time / <int64_t>USECS_PER_HOUR
+        time -= tfrac * <int64_t>USECS_PER_HOUR
+        hour = tfrac
+
+        if (hour < 0) != (tfrac < 0):
+            raise ValueError('interval out of range')
+
+        tfrac = time / <int64_t>USECS_PER_MINUTE
+        time -= tfrac * <int64_t>USECS_PER_MINUTE
+        min = tfrac
+        sec = time / USECS_PER_SEC
+        fsec = time - sec * USECS_PER_SEC
+
+        if year:
+            buf.append('{}{}{} year{}'.format(
+                '' if is_first else ' ',
+                '+' if is_before and year > 0 else '',
+                year,
+                's' if year != 1 else ''))
+
+            is_first = False
+            is_before = year < 0
+
+        if mon:
+            buf.append('{}{}{} month{}'.format(
+                '' if is_first else ' ',
+                '+' if is_before and mon > 0 else '',
+                mon,
+                's' if mon != 1 else ''))
+
+            is_first = False
+            is_before = mon < 0
+
+        if self.days:
+            buf.append('{}{}{} day{}'.format(
+                '' if is_first else ' ',
+                '+' if is_before and self.days > 0 else '',
+                self.days,
+                's' if self.days != 1 else ''))
+
+            is_first = False
+            is_before = self.days < 0
+
+        if is_first or hour != 0 or min != 0 or sec != 0 or fsec != 0:
+            neg = hour < 0 or min < 0 or sec < 0 or fsec < 0
+            buf.append('{}{}{:0>2}:{:0>2}:{:0>2}'.format(
+                '' if is_first else ' ',
+                '-' if neg else ('+' if is_before else ''),
+                abs(hour), abs(min), abs(sec)))
+
+            fsec = abs(fsec)
+            if fsec:
+                buf.append(f'.{fsec:0>6}'.rstrip('0'))
+
+        return ''.join(buf)
+
+
+cdef new_duration(int64_t microseconds, int32_t days, int32_t months):
+    cdef Duration dur = Duration.__new__(Duration)
+
+    dur.microseconds = microseconds
+    dur.days = days
+    dur.months = months
+
+    return dur

--- a/edgedb/protocol/codecs/edb_types.pxi
+++ b/edgedb/protocol/codecs/edb_types.pxi
@@ -24,6 +24,6 @@ TYPE_IDS = {
     'std::local_datetime': uuid.UUID('00000000-0000-0000-0000-00000000010b'),
     'std::local_date': uuid.UUID('00000000-0000-0000-0000-00000000010c'),
     'std::local_time': uuid.UUID('00000000-0000-0000-0000-00000000010d'),
-    'std::timedelta': uuid.UUID('00000000-0000-0000-0000-00000000010e'),
+    'std::duration': uuid.UUID('00000000-0000-0000-0000-00000000010e'),
     'std::json': uuid.UUID('00000000-0000-0000-0000-00000000010f'),
 }

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,87 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import random
+
+import edgedb
+from edgedb import _testbase as tb
+
+
+class TestDatetimeTypes(tb.SyncQueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    async def test_duration_01(self):
+
+        duration_kwargs = [
+            dict(),
+            dict(microseconds=1),
+            dict(microseconds=-1),
+            dict(days=1),
+            dict(days=-1),
+            dict(months=1),
+            dict(months=-1),
+            dict(microseconds=1, days=1, months=1),
+            dict(microseconds=-1, days=-1, months=-1),
+        ]
+
+        # Fuzz it!
+        for _ in range(5000):
+            duration_kwargs.append(
+                dict(
+                    microseconds=random.randint(-1000000000, 1000000000),
+                    days=random.randint(-500, 500),
+                    months=random.randint(-50, 50)
+                )
+            )
+
+        durs = [edgedb.Duration(**d) for d in duration_kwargs]
+
+        # Test that Duration.__str__ formats the same as <str><duration>
+        durs_as_text = self.con.fetchall('''
+            WITH args := array_unpack(<array<duration>>$0)
+            SELECT <str>args;
+        ''', durs)
+
+        # Test encode/decode roundtrip
+        durs_from_db = self.con.fetchall('''
+            WITH args := array_unpack(<array<duration>>$0)
+            SELECT args;
+        ''', durs)
+
+        self.assertEqual(durs_as_text, [str(d) for d in durs])
+        self.assertEqual(list(durs_from_db), durs)
+
+    async def test_duration_02(self):
+        d1 = edgedb.Duration(microseconds=1)
+        d2 = edgedb.Duration(microseconds=2)
+        d3 = edgedb.Duration(microseconds=1)
+
+        self.assertNotEqual(d1, d2)
+        self.assertEqual(d1, d3)
+
+        self.assertEqual(hash(d1), hash(d3))
+        if hash(1) != hash(2):
+            self.assertNotEqual(hash(d1), hash(d2))
+
+        self.assertEqual(d1.days, 0)
+        self.assertEqual(d1.months, 0)
+        self.assertEqual(d1.microseconds, 1)
+
+        self.assertEqual(repr(d1), '<edgedb.Duration "00:00:00.000001">')


### PR DESCRIPTION
Following the "timedelta" rename in EdgeDB, we are introducing a new
type in the EdgeDB Python driver.

The builtin datetime.timedelta is, unfortunately, not very usable,
compared to dateutil.relativedelta.  Using the latter means adding
dateutil as a dependancy, which is something we'd like to avoid.