### PR TITLE
Add type hints for connections and transactions

### DIFF
--- a/edgedb/__init__.py
+++ b/edgedb/__init__.py
@@ -25,14 +25,15 @@ from edgedb.datatypes.datatypes import Tuple, NamedTuple, EnumValue
 from edgedb.datatypes.datatypes import Set, Object, Array, Link, LinkSet
 from edgedb.datatypes.datatypes import Duration
 
-from .asyncio_con import async_connect
+from .asyncio_con import async_connect, AsyncIOConnection
 from .asyncio_pool import create_async_pool, AsyncIOPool
-from .blocking_con import connect
+from .blocking_con import connect, BlockingIOConnection
 from .transaction import Transaction, AsyncIOTransaction
 
-
 __all__ = (
-    'async_connect', 'connect', 'create_async_pool', 'AsyncIOPool',
+    'async_connect', 'AsyncIOConnection',
+    'connect', 'BlockingIOConnection',
+    'create_async_pool', 'AsyncIOPool',
     'EnumValue', 'Tuple', 'NamedTuple', 'Set',
     'Object', 'Array', 'Link', 'LinkSet',
     'Transaction', 'AsyncIOTransaction',

--- a/setup.py
+++ b/setup.py
@@ -281,6 +281,7 @@ setuptools.setup(
     provides=['edgedb'],
     zip_safe=False,
     include_package_data=True,
+    package_data={'edgedb': ['py.typed']},
     ext_modules=[
         distutils_extension.Extension(
             "edgedb.pgproto.pgproto",


### PR DESCRIPTION
Fixes #23 

Preview of what this looks like (VSCode):

![Screenshot 2019-06-22 at 00 20 26](https://user-images.githubusercontent.com/15911462/59954148-8edd3880-9483-11e9-999a-f442fa9e75b2.png)

![Screenshot 2019-06-21 at 23 41 39](https://user-images.githubusercontent.com/15911462/59954151-93a1ec80-9483-11e9-9249-caa082c55d04.png)

![Screenshot 2019-06-21 at 23 41 26](https://user-images.githubusercontent.com/15911462/59954153-956bb000-9483-11e9-8d46-cdf78b9f1a80.png)

![Screenshot 2019-06-21 at 23 54 59](https://user-images.githubusercontent.com/15911462/59954155-9997cd80-9483-11e9-8d14-f20bf62b924f.png)

Notes:

- I used `Set` and `Object` for the return types of `.fetchall()` and `.fetchone()`, but I'm not 100% sure they're the good ones to use.
- The built-in datatypes such as `Set`, `Object`, `Link`, etc. are defined in Cython, so obviously IDE's can't pick them up for autocomplete. I believe we could find a way to provide MyPy stub files for these(see [examples](https://github.com/python/mypy/wiki/Creating-Stubs-For-Python-Modules#examples)), but not sure whether that's something IDEs can pick up. Thankfully, the [documentation](https://edgedb.com/docs/clients/00_python/api/types) on datatypes is very thorough, but I'm still thinking it would be really nice to get autocompletion for these as well. Any thoughts?