### PR TITLE
Update usage of asyncio.get_event_loop()

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -102,11 +102,11 @@ Connection
 
         >>> import asyncio
         >>> import edgedb
-        >>> async def run():
+        >>> async def main():
         ...     con = await edgedb.async_connect(user='edgedeb')
         ...     print(await con.fetchone('SELECT 1 + 1'))
         ...
-        >>> asyncio.get_event_loop().run_until_complete(run())
+        >>> asyncio.run(main())
         {2}
 
 

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -206,7 +206,7 @@ async def async_connect(dsn: str = None, *,
                         connection_class=None,
                         timeout: int = 60) -> AsyncIOConnection:
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     if connection_class is None:
         connection_class = AsyncIOConnection


### PR DESCRIPTION
The motivation for this PR was from a recent discussion with @1st1 regarding the usage of `asyncio.get_event_loop()`. 

Within the context of coroutines, it is [recommended](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) to use `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()`. This is because the behavior or `asyncio.get_event_loop()` is significantly more complex and implicit in comparison to `asyncio.get_running_loop()`. The [performance](https://gist.github.com/aeros/b328f04f15af68543466f41dc2be118a) difference between the two is fairly negligible; with `asyncio.get_running_loop()` being slightly faster.

Additionally, I updated the examples in the docs to use `asyncio.run(coro)` instead of using `loop = asyncio.get_event_loop(); loop.run_until_complete(coro)` or `loop.get_event_loop().run_until_complete(coro)`. `asyncio.run()` was provisionally added to the asyncio API in 3.7, but it is no longer provisional.