### PR TITLE
Upgrade flake8 and fix pycodestyle version

### DIFF
--- a/edgedb/_cluster.py
+++ b/edgedb/_cluster.py
@@ -123,7 +123,7 @@ class Cluster:
 
         return edgedb.connect(**connect_args)
 
-    def init(self, *, server_settings={}):
+    def init(self):
         cluster_status = self.get_status()
 
         if not cluster_status.startswith('not-initialized'):

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -49,7 +49,7 @@ def silence_asyncio_long_exec_warning():
 _default_cluster = None
 
 
-def _init_cluster(data_dir=None, *, cleanup_atexit=True, init_settings={}):
+def _init_cluster(data_dir=None, *, cleanup_atexit=True):
     if (not os.environ.get('EDGEDB_DEBUG_SERVER') and
             not os.environ.get('EDGEDB_LOG_LEVEL')):
         _env = {'EDGEDB_LOG_LEVEL': 'silent'}
@@ -64,7 +64,7 @@ def _init_cluster(data_dir=None, *, cleanup_atexit=True, init_settings={}):
         destroy = False
 
     if cluster.get_status() == 'not-initialized':
-        cluster.init(server_settings=init_settings)
+        cluster.init()
 
     cluster.start(port='dynamic')
     cluster.set_superuser_password('test')

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ CYTHON_DEPENDENCY = 'Cython==0.29.13'
 
 # Minimal dependencies required to test edgedb.
 TEST_DEPENDENCIES = [
-    'flake8~=3.5.0',
+    # pycodestyle is a dependency of flake8, but it must be frozen because
+    # their combination breaks too often
+    # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
+    'pycodestyle~=2.5.0',
+    'flake8~=3.7.9',
     'uvloop>=0.12.0rc1;platform_system!="Windows"',
 ]
 

--- a/tests/datatypes/test_datatypes.py
+++ b/tests/datatypes/test_datatypes.py
@@ -167,7 +167,7 @@ class TestTuple(unittest.TestCase):
 
     def test_tuple_freelist_1(self):
         lst = []
-        for i in range(5000):
+        for _ in range(5000):
             lst.append(edgedb.Tuple((1,)))
         for t in lst:
             self.assertEqual(t[0], 1)


### PR DESCRIPTION
Also added ignore of B006, because it warns in the following way:
```
./_testbase.py:52:72: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./_cluster.py:126:39: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
```
Which is pretty safe at that instances.

**Or maybe fix specific instances?**

----

Without the upgrade it fails like this, because pycodestyle is not frozen (and upgraded since I've installed from scratch):
```
                                                        
    yield func(self.plugins[name], *args, **kwargs)                                                                                                           
  File "/usr/local/lib/python3.7/dist-packages/flake8/plugins/manager.py", line 421, in load_plugin                                                           
    return plugin.load_plugin()                                                                                                                               
  File "/usr/local/lib/python3.7/dist-packages/flake8/plugins/manager.py", line 186, in load_plugin                                                           
    raise failed_to_load                                                                                                                                      
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "pycodestyle.break_after_binary_operator" due to module 'pycodestyle' has no attribute 'break_after_binary_operator'.
```