### PR TITLE
Fixes error handling tests.

### DIFF
--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -35,7 +35,8 @@ class TestProto(tb.SyncQueryTestCase):
                 # we know that the codec will fail.
                 # The test will be rewritten once it's possible to override
                 # default codecs.
-                self.con.fetchall("SELECT to_local_date('0001-01-01 BC');")
+                self.con.fetchall(
+                    "SELECT to_local_date('0001-01-01 BC', 'YYYY-MM-DD AD');")
 
             # The protocol, though, shouldn't be in some inconsistent
             # state; it should allow new queries to execute successfully.
@@ -52,15 +53,18 @@ class TestProto(tb.SyncQueryTestCase):
                 # we know that the codec will fail.
                 # The test will be rewritten once it's possible to override
                 # default codecs.
-                self.con.fetchall("""
-                    SELECT to_local_date({
-                        '2010-01-01',
-                        '2010-01-02',
-                        '2010-01-03',
-                        '0001-01-01 BC',
-                        '2010-01-04',
-                        '2010-01-05',
-                    });
+                self.con.fetchall(r"""
+                    SELECT to_local_date(
+                        {
+                            '2010-01-01 AD',
+                            '2010-01-02 AD',
+                            '2010-01-03 AD',
+                            '0001-01-01 BC',
+                            '2010-01-04 AD',
+                            '2010-01-05 AD',
+                        },
+                        'YYYY-MM-DD AD'
+                    );
                 """)
 
             # The protocol, though, shouldn't be in some inconsistent


### PR DESCRIPTION
There was a bug in `to_local...` converter functions that made them too
permissive when invoked without format string. The fix for that makes it
necessary to update some tests using `to_local_date` with a format
string.

Related to #42