### PR TITLE
Use timedelta for std::duration, rename Duration -> RelativeDelta

### DIFF
--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -42,7 +42,8 @@ The table below shows the correspondence between EdgeDB and Python types.
 | ``datetime``         | offset-aware :py:class:`datetime.datetime \         |
 |                      | <python:datetime.datetime>`                         |
 +----------------------+-----------------------------------------------------+
-| ``duration``         | :py:class:`edgedb.Duration`                         |
+| ``duration``         | :py:class:`datetime.timedelta \                     |
+|                      | <python:datetime.timedelta>`                        |
 +----------------------+-----------------------------------------------------+
 | ``float32``,         | :py:class:`float <python:float>`                    |
 | ``float64``          |                                                     |
@@ -241,23 +242,3 @@ Arrays
         2
         >>> r == [1, 2, 3]
         True
-
-
-Duration
-========
-
-.. py:class:: Duration(*, months, days, microseconds)
-
-    A Python representation of an EdgeDB ``duration`` value.
-
-    .. py:attribute:: months
-
-        The number of months in the duration.
-
-    .. py:attribute:: days
-
-        The number of days in the duration.
-
-    .. py:attribute:: microseconds
-
-        The number of microseconds in the duration.

--- a/edgedb/__init__.py
+++ b/edgedb/__init__.py
@@ -23,7 +23,6 @@ from ._version import __version__
 
 from edgedb.datatypes.datatypes import Tuple, NamedTuple, EnumValue
 from edgedb.datatypes.datatypes import Set, Object, Array, Link, LinkSet
-from edgedb.datatypes.datatypes import Duration
 
 from .asyncio_con import async_connect, AsyncIOConnection
 from .asyncio_pool import create_async_pool, AsyncIOPool

--- a/edgedb/datatypes/datatypes.pxd
+++ b/edgedb/datatypes/datatypes.pxd
@@ -21,7 +21,7 @@ cimport cython
 cimport cpython
 
 
-include "./duration.pxd"
+include "./relative_delta.pxd"
 include "./enum.pxd"
 
 

--- a/edgedb/datatypes/datatypes.pyx
+++ b/edgedb/datatypes/datatypes.pyx
@@ -20,7 +20,7 @@
 cimport cython
 cimport cpython
 
-include "./duration.pyx"
+include "./relative_delta.pyx"
 include "./enum.pyx"
 
 

--- a/edgedb/datatypes/relative_delta.pxd
+++ b/edgedb/datatypes/relative_delta.pxd
@@ -21,7 +21,7 @@ from libc.stdint cimport int64_t, int32_t
 
 
 @cython.final
-cdef class Duration:
+cdef class RelativeDelta:
 
     cdef:
         readonly int64_t microseconds

--- a/edgedb/datatypes/relative_delta.pyx
+++ b/edgedb/datatypes/relative_delta.pyx
@@ -28,7 +28,7 @@ DEF MAX_INTERVAL_PRECISION  = 6
 
 
 @cython.final
-cdef class Duration:
+cdef class RelativeDelta:
 
     def __init__(self, *, int64_t microseconds=0,
                  int32_t days=0, int32_t months=0):
@@ -37,20 +37,20 @@ cdef class Duration:
         self.months = months
 
     def __eq__(self, other):
-        if type(other) is not Duration:
+        if type(other) is not RelativeDelta:
             return NotImplemented
 
         return (
-            self.microseconds == (<Duration>other).microseconds and
-            self.days == (<Duration>other).days and
-            self.months == (<Duration>other).months
+            self.microseconds == (<RelativeDelta>other).microseconds and
+            self.days == (<RelativeDelta>other).days and
+            self.months == (<RelativeDelta>other).months
         )
 
     def __hash__(self):
-        return hash((Duration, self.microseconds, self.days, self.months))
+        return hash((RelativeDelta, self.microseconds, self.days, self.months))
 
     def __repr__(self):
-        return f'<edgedb.Duration "{self}">'
+        return f'<edgedb.RelativeDelta "{self}">'
 
     @cython.cdivision(True)
     def __str__(self):
@@ -127,7 +127,7 @@ cdef class Duration:
 
 
 cdef new_duration(int64_t microseconds, int32_t days, int32_t months):
-    cdef Duration dur = Duration.__new__(Duration)
+    cdef RelativeDelta dur = RelativeDelta.__new__(RelativeDelta)
 
     dur.microseconds = microseconds
     dur.days = days


### PR DESCRIPTION
The RelativeDelta itself is not used and not documented, for now, but it should be enabled shortly so I decided to keep it in the codebase.