### PR TITLE
v0.7.0a4

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.7.0a3'
+__version__ = '0.7.0a4'


### PR DESCRIPTION
Bump the version to 0.7.0a4.  New features include support for
the dump/restore sub-protocol.