### PR TITLE
Use 32-bit length prefixed strings in descriptors

### DIFF
--- a/edgedb/protocol/codecs/codecs.pyx
+++ b/edgedb/protocol/codecs/codecs.pyx
@@ -63,7 +63,7 @@ cdef class CodecsRegistry:
             bytes tid = frb_read(spec, 16)[:16]
             uint16_t els
             uint16_t i
-            uint16_t str_len
+            uint32_t str_len
             uint16_t pos
             int32_t dim_len
             BaseCodec res

--- a/edgedb/protocol/codecs/codecs.pyx
+++ b/edgedb/protocol/codecs/codecs.pyx
@@ -84,7 +84,7 @@ cdef class CodecsRegistry:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
                     frb_read(spec, 1)
-                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                    str_len = hton.unpack_uint32(frb_read(spec, 4))
                     # read the <str> (`str_len` bytes) and <pos> (2 bytes)
                     frb_read(spec, str_len + 2)
 
@@ -103,7 +103,7 @@ cdef class CodecsRegistry:
             elif t == CTYPE_NAMEDTUPLE:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
-                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                    str_len = hton.unpack_uint32(frb_read(spec, 4))
                     frb_read(spec, str_len + 2)
 
             elif t == CTYPE_ARRAY:
@@ -118,12 +118,12 @@ cdef class CodecsRegistry:
             elif t == CTYPE_ENUM:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
-                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                    str_len = hton.unpack_uint32(frb_read(spec, 4))
                     frb_read(spec, str_len)
 
             elif (t >= 0xf0 and t <= 0xff):
                 # Ignore all type annotations.
-                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                str_len = hton.unpack_uint32(frb_read(spec, 4))
                 frb_read(spec, str_len)
 
             else:
@@ -145,7 +145,7 @@ cdef class CodecsRegistry:
             for i in range(els):
                 flag = <uint8_t>frb_read(spec, 1)[0]
 
-                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                str_len = hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
                 pos = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
@@ -191,7 +191,7 @@ cdef class CodecsRegistry:
             codecs = cpython.PyTuple_New(els)
             names = cpython.PyTuple_New(els)
             for i in range(els):
-                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                str_len = hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
                 pos = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
@@ -209,7 +209,7 @@ cdef class CodecsRegistry:
             els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
             names = cpython.PyTuple_New(els)
             for i in range(els):
-                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+                str_len = hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
 
@@ -231,7 +231,7 @@ cdef class CodecsRegistry:
 
         elif (t >= 0xf0 and t <= 0xff):
             # Ignore all type annotations.
-            str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
+            str_len = hton.unpack_uint32(frb_read(spec, 4))
             frb_read(spec, str_len)
             return
 

--- a/edgedb/protocol/codecs/codecs.pyx
+++ b/edgedb/protocol/codecs/codecs.pyx
@@ -123,7 +123,7 @@ cdef class CodecsRegistry:
 
             elif (t >= 0xf0 and t <= 0xff):
                 # Ignore all type annotations.
-                str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                 frb_read(spec, str_len)
 
             else:
@@ -145,7 +145,7 @@ cdef class CodecsRegistry:
             for i in range(els):
                 flag = <uint8_t>frb_read(spec, 1)[0]
 
-                str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
                 pos = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
@@ -191,7 +191,7 @@ cdef class CodecsRegistry:
             codecs = cpython.PyTuple_New(els)
             names = cpython.PyTuple_New(els)
             for i in range(els):
-                str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
                 pos = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
@@ -209,7 +209,7 @@ cdef class CodecsRegistry:
             els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
             names = cpython.PyTuple_New(els)
             for i in range(els):
-                str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                 name = cpythonx.PyUnicode_FromStringAndSize(
                     frb_read(spec, str_len), str_len)
 
@@ -231,7 +231,7 @@ cdef class CodecsRegistry:
 
         elif (t >= 0xf0 and t <= 0xff):
             # Ignore all type annotations.
-            str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+            str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
             frb_read(spec, str_len)
             return
 

--- a/edgedb/protocol/codecs/codecs.pyx
+++ b/edgedb/protocol/codecs/codecs.pyx
@@ -84,7 +84,7 @@ cdef class CodecsRegistry:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
                     frb_read(spec, 1)
-                    str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                     # read the <str> (`str_len` bytes) and <pos> (2 bytes)
                     frb_read(spec, str_len + 2)
 
@@ -103,7 +103,7 @@ cdef class CodecsRegistry:
             elif t == CTYPE_NAMEDTUPLE:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
-                    str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                     frb_read(spec, str_len + 2)
 
             elif t == CTYPE_ARRAY:
@@ -118,7 +118,7 @@ cdef class CodecsRegistry:
             elif t == CTYPE_ENUM:
                 els = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
                 for i in range(els):
-                    str_len = <uint16_t>hton.unpack_int16(frb_read(spec, 2))
+                    str_len = <uint32_t>hton.unpack_uint32(frb_read(spec, 4))
                     frb_read(spec, str_len)
 
             elif (t >= 0xf0 and t <= 0xff):


### PR DESCRIPTION
This depends on [PR in pgproto](https://github.com/MagicStack/py-pgproto/pull/3) and [PR in edgedb](https://github.com/edgedb/edgedb/pull/1031).