### PR TITLE
Add a private Connection._set_type_codec() method.

### DIFF
--- a/edgedb/base_con.py
+++ b/edgedb/base_con.py
@@ -19,6 +19,7 @@
 
 import itertools
 import typing
+import uuid
 
 from . import errors
 
@@ -53,6 +54,21 @@ class BaseConnection:
             self._query_cache = _QueryCodecsCache()
 
         self._top_xact = None
+
+    def _set_type_codec(
+        self,
+        typeid: uuid.UUID,
+        *,
+        encoder: typing.Callable[[typing.Any], typing.Any],
+        decoder: typing.Callable[[typing.Any], typing.Any],
+        format: str
+    ):
+        self._codecs_registry.set_type_codec(
+            typeid,
+            encoder=encoder,
+            decoder=decoder,
+            format=format,
+        )
 
     def _dispatch_log_message(self, msg):
         raise NotImplementedError

--- a/edgedb/protocol/codecs/base.pxd
+++ b/edgedb/protocol/codecs/base.pxd
@@ -32,6 +32,20 @@ cdef class BaseCodec:
     cdef dump(self, int level=?)
 
 
+cdef class CodecPythonOverride(BaseCodec):
+
+    cdef:
+        BaseCodec codec
+        object encoder
+        object decoder
+
+    @staticmethod
+    cdef BaseCodec new(bytes tid,
+                       BaseCodec basecodec,
+                       object encoder,
+                       object decoder)
+
+
 cdef class BaseRecordCodec(BaseCodec):
 
     cdef:

--- a/edgedb/protocol/codecs/base.pyx
+++ b/edgedb/protocol/codecs/base.pyx
@@ -47,6 +47,40 @@ cdef class BaseCodec:
         return f'{level * " "}{self.name}'
 
 
+cdef class CodecPythonOverride(BaseCodec):
+
+    def __cinit__(self):
+        self.codec = None
+        self.encoder = None
+        self.decoder = None
+
+    cdef encode(self, WriteBuffer buf, object obj):
+        self.codec.encode(buf, self.encoder(obj))
+
+    cdef decode(self, FRBuffer *buf):
+        return self.decoder(self.codec.decode(buf))
+
+    cdef dump(self, int level = 0):
+        return f'{level * " "}<Python override>{self.name}'
+
+    @staticmethod
+    cdef BaseCodec new(bytes tid,
+                       BaseCodec basecodec,
+                       object encoder,
+                       object decoder):
+
+        cdef:
+            CodecPythonOverride codec
+
+        codec = CodecPythonOverride.__new__(CodecPythonOverride)
+        codec.tid = tid
+        codec.name = basecodec.name
+        codec.codec = basecodec
+        codec.encoder = encoder
+        codec.decoder = decoder
+        return codec
+
+
 cdef class EmptyTupleCodec(BaseCodec):
 
     def __cinit__(self):

--- a/edgedb/protocol/codecs/codecs.pxd
+++ b/edgedb/protocol/codecs/codecs.pxd
@@ -32,6 +32,7 @@ cdef class CodecsRegistry:
     cdef:
         LRUMapping codecs_build_cache
         LRUMapping codecs
+        dict base_codec_overrides
 
     cdef BaseCodec _build_codec(self, FRBuffer *spec, list codecs_list)
     cdef BaseCodec build_codec(self, bytes spec)


### PR DESCRIPTION
Similarly to asyncpg, this method allows to override the base
type codec for EdgeDB connections.  Right now the only format
supported is "python" -- which allows to wrap standard Python
decoded/encoded values with custom logic.

This is needed to allow proper rendering of std::bigint values
in our repl.

See also https://github.com/edgedb/edgedb/issues/924