### PR TITLE
docs: Add a note about using JSON when fetching values.

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -164,6 +164,18 @@ Connection
 
         Note, that positional and named query arguments cannot be mixed.
 
+        .. note::
+
+            Caution is advised when reading ``decimal`` values using
+            this method. The JSON specification does not have a limit
+            on significant digits, so a ``decimal`` number can be
+            losslessly represented in JSON. However, the default JSON
+            decoder in Python will read all such numbers as ``float``
+            values, which may result in errors or precision loss. If
+            such loss is unacceptable, then consider casting the value
+            into ``str`` and decoding it on the client side into a
+            more appropriate type, such as ``Decimal``.
+
 
     .. py:coroutinemethod:: fetchone_json(query, *args, **kwargs)
 
@@ -182,6 +194,18 @@ Connection
         is raised.
 
         Note, that positional and named query arguments cannot be mixed.
+
+        .. note::
+
+            Caution is advised when reading ``decimal`` values using
+            this method. The JSON specification does not have a limit
+            on significant digits, so a ``decimal`` number can be
+            losslessly represented in JSON. However, the default JSON
+            decoder in Python will read all such numbers as ``float``
+            values, which may result in errors or precision loss. If
+            such loss is unacceptable, then consider casting the value
+            into ``str`` and decoding it on the client side into a
+            more appropriate type, such as ``Decimal``.
 
 
     .. py:coroutinemethod:: execute(query)

--- a/docs/api/blocking_con.rst
+++ b/docs/api/blocking_con.rst
@@ -160,6 +160,18 @@ Connection
 
         Note, that positional and named query arguments cannot be mixed.
 
+        .. note::
+
+            Caution is advised when reading ``decimal`` values using
+            this method. The JSON specification does not have a limit
+            on significant digits, so a ``decimal`` number can be
+            losslessly represented in JSON. However, the default JSON
+            decoder in Python will read all such numbers as ``float``
+            values, which may result in errors or precision loss. If
+            such loss is unacceptable, then consider casting the value
+            into ``str`` and decoding it on the client side into a
+            more appropriate type, such as ``Decimal``.
+
 
     .. py:method:: fetchone_json(query, *args, **kwargs)
 
@@ -178,6 +190,18 @@ Connection
         is raised.
 
         Note, that positional and named query arguments cannot be mixed.
+
+        .. note::
+
+            Caution is advised when reading ``decimal`` values using
+            this method. The JSON specification does not have a limit
+            on significant digits, so a ``decimal`` number can be
+            losslessly represented in JSON. However, the default JSON
+            decoder in Python will read all such numbers as ``float``
+            values, which may result in errors or precision loss. If
+            such loss is unacceptable, then consider casting the value
+            into ``str`` and decoding it on the client side into a
+            more appropriate type, such as ``Decimal``.
 
 
     .. py:method:: execute(query)

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -49,7 +49,8 @@ The table below shows the correspondence between EdgeDB and Python types.
 +----------------------+-----------------------------------------------------+
 | ``int16``,           | :py:class:`int <python:int>`                        |
 | ``int32``,           |                                                     |
-| ``int64``            |                                                     |
+| ``int64``,           |                                                     |
+| ``bigint``           |                                                     |
 +----------------------+-----------------------------------------------------+
 | ``decimal``          | :py:class:`Decimal <python:decimal.Decimal>`        |
 +----------------------+-----------------------------------------------------+


### PR DESCRIPTION
Add a cautionary note about fetching `decimal` values using
`fetchall_json` or `fetchone_json`.

This is trying to address https://github.com/edgedb/edgedb/issues/1151