### PR TITLE
v0.9.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.9.0a1'
+__version__ = '0.9.0'


### PR DESCRIPTION
* API rename: "fetch" to "query" (#51)
* Expose `query*()` methods in the Pool class directly