### PR TITLE
Docs: Add note to Connection.execute()

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -230,6 +230,10 @@ Connection
             ...     UNION INSERT MyType { a := x };
             ... ''')
 
+        .. note::
+            If the results of *query* are desired, :py:meth:`query` or
+            :py:meth:`query_one` should be used instead.
+
 
     .. py:method:: transaction(isolation=None, readonly=None, deferrable=None)
 

--- a/docs/api/blocking_con.rst
+++ b/docs/api/blocking_con.rst
@@ -226,6 +226,10 @@ Connection
             ...     UNION INSERT MyType { a := x };
             ... ''')
 
+        .. note::
+            If the results of *query* are desired, :py:meth:`query` or
+            :py:meth:`query_one` should be used instead.
+
 
     .. py:method:: transaction(isolation=None, readonly=None, deferrable=None)
 


### PR DESCRIPTION
Clarifies that Connection.query() and Connection.query_one() should be used if the results are needed, instead of Connection.execute().

This was brought up in https://github.com/edgedb/edgedb-python/issues/51#issuecomment-614920072, but not directly related to the main issue.

Preview:

![image](https://user-images.githubusercontent.com/44193521/87610017-25554b00-c6d2-11ea-9097-e647615544be.png)
