### PR TITLE
AsyncIOPool.free_size property implementation

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -531,14 +531,14 @@ Connection Pools
         See :py:meth:`AsyncIOConnection.execute()
         <edgedb.AsyncIOConnection.execute>` for details.
 
-    .. py:attribute:: min_size()
+    .. py:attribute:: min_size
 
         Number of connection the pool was initialized with.
 
-    .. py:attribute:: max_size()
+    .. py:attribute:: max_size
 
         Max number of connections in the pool.
 
-    .. py:attribute:: free_size()
+    .. py:attribute:: free_size
 
         Number of available connections in the pool.

--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -530,3 +530,15 @@ Connection Pools
 
         See :py:meth:`AsyncIOConnection.execute()
         <edgedb.AsyncIOConnection.execute>` for details.
+
+    .. py:attribute:: min_size()
+
+        Number of connection the pool was initialized with.
+
+    .. py:attribute:: max_size()
+
+        Max number of connections in the pool.
+
+    .. py:attribute:: free_size()
+
+        Number of available connections in the pool.

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -291,8 +291,8 @@ class AsyncIOPool:
                  '_on_acquire', '_on_release')
 
     def __init__(self, *connect_args,
-                 min_size,
-                 max_size,
+                 min_size: int,
+                 max_size: int,
                  on_acquire,
                  on_release,
                  on_connect,
@@ -340,6 +340,28 @@ class AsyncIOPool:
         self._on_connect = on_connect
         self._connect_args = connect_args
         self._connect_kwargs = connect_kwargs
+
+    @property
+    def min_size(self) -> int:
+        """Number of connection the pool was initialized with."""
+
+        return self._minsize
+
+    @property
+    def max_size(self) -> int:
+        """Max number of connections in the pool."""
+
+        return self._maxsize
+
+    @property
+    def free_size(self) -> int:
+        """Number of available connections in the pool."""
+
+        if self._queue is None:
+            # Queue has not been initialized yet
+            return self._maxsize
+
+        return self._queue.qsize()
 
     async def _async__init__(self):
         if self._initialized:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -521,12 +521,16 @@ class TestPool(tb.AsyncQueryTestCase):
         min_size = 1
         max_size = 2
 
-        pool = await self.create_pool(min_size=min_size, max_size=max_size)
+        pool = self.create_pool(min_size=min_size, max_size=max_size)
         self.assertEqual(pool.min_size, min_size)
         self.assertEqual(pool.max_size, max_size)
         self.assertEqual(pool.free_size, max_size)
 
+        await pool
+
         async with pool.acquire() as _:
             self.assertEqual(pool.free_size, max_size - 1)
+
+        self.assertEqual(pool.free_size, max_size)
 
         await pool.aclose()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -516,3 +516,17 @@ class TestPool(tb.AsyncQueryTestCase):
 
         await pool_task
         await pool.aclose()
+
+    async def test_pool_properties(self):
+        min_size = 1
+        max_size = 2
+
+        pool = await self.create_pool(min_size=min_size, max_size=max_size)
+        self.assertEqual(pool.min_size, min_size)
+        self.assertEqual(pool.max_size, max_size)
+        self.assertEqual(pool.free_size, max_size)
+
+        async with pool.acquire() as _:
+            self.assertEqual(pool.free_size, max_size - 1)
+
+        await pool.aclose()


### PR DESCRIPTION
Also implements `min_size` and `max_size`.

Resolves: #109 