### PR TITLE
Add support of connecting to instance by a name

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -28,9 +28,11 @@ Connection
 
     Returns a new :py:class:`AsyncIOConnection` object.
 
-    :param dsn:
-        Connection arguments specified using as a single string in the
-        connection URI format:
+    :param str dsn:
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
+
+        Otherwise it specifies a single string in the following format:
         ``edgedb://user:password@host:port/database?option=value``.
         The following options are recognized: host, port,
         user, database, password.
@@ -472,8 +474,10 @@ Connection Pools
         Set the new connection arguments for this pool.
 
         :param str dsn:
-            Connection arguments specified using as a single string in
-            the following format:
+            If this parameter does not start with ``edgedb://`` then this is
+            a :ref:`name of an instance <edgedb-instances>`.
+
+            Otherwise it specifies a single string in the following format:
             ``edgedb://user:pass@host:port/database?option=value``.
 
         :param \*\*connect_kwargs:

--- a/docs/api/blocking_con.rst
+++ b/docs/api/blocking_con.rst
@@ -22,8 +22,10 @@ Connection
     Establish a connection to an EdgeDB server.
 
     :param dsn:
-        Connection arguments specified using as a single string in the
-        connection URI format:
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
+
+        Otherwise it specifies a single string in the connection URI format:
         ``edgedb://user:password@host:port/database?option=value``.
         The following options are recognized: host, port,
         user, database, password.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ and :ref:`asyncio <edgedb-python-asyncio-api-reference>` implementations.
 
    installation
    usage
+   instances
    api/asyncio_con
    api/blocking_con
    api/types

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -1,0 +1,27 @@
+.. _edgedb-instances:
+
+Instance Names
+==============
+
+Here are some ways to connect to an EdgeDB instance by a name:
+
+.. code-block:: python
+
+   conn = edgedb.connect('my_name')
+   conn = await edgedb.async_connect('my_name')
+   pool = await edgedb.create_async_pool('my_name')
+
+This usually refer to instances created by the command-line tool:
+
+.. code-block:: shell
+
+   edgedb server init my_name
+
+When the command is run, it puts a credentials file into users home directory::
+
+    $HOME/.edgedb/credentials/my_name.json
+
+This file is read by Python bindings to discover the database instance.
+
+You are free to add additional JSON files with access to remote databases into
+the ``credentials`` directory.

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -289,7 +289,7 @@ async def _connect_addr(*, addr, loop, timeout, params, config,
 async def async_connect(dsn: str = None, *,
                         host: str = None, port: int = None,
                         user: str = None, password: str = None,
-                        admin: str = None,
+                        admin: bool = None,
                         database: str = None,
                         connection_class=None,
                         timeout: int = 60) -> AsyncIOConnection:

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -766,8 +766,10 @@ def create_async_pool(dsn=None, *,
             await pool.release(con)
 
     :param str dsn:
-        Connection arguments specified using as a single string in
-        the following format:
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
+
+        Otherwies it specifies as a single string in the following format:
         ``edgedb://user:pass@host:port/database?option=value``.
 
     :param \*\*connect_kwargs:

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -237,7 +237,7 @@ def _connect_addr(*, addr, timeout, params, config, connection_class):
 def connect(dsn: str = None, *,
             host: str = None, port: int = None,
             user: str = None, password: str = None,
-            admin: str = None,
+            admin: bool = None,
             database: str = None,
             timeout: int = 60) -> BlockingIOConnection:
 

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -22,8 +22,11 @@ import os
 import platform
 import typing
 import urllib.parse
+import warnings
+import pathlib
 
 from . import errors
+from . import credentials
 
 
 EDGEDB_PORT = 5656
@@ -104,11 +107,24 @@ def _parse_hostlist(hostlist, port):
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                                 password, database, admin,
                                 connect_timeout, server_settings):
+    if admin:
+        warnings.warn(
+            'The "admin=True" parameter is deprecated and is scheduled to be '
+            'removed. Admin socket should never be used in applications. '
+            'Use command-line tool `edgedb` to setup proper credentials.',
+            DeprecationWarning, 4)
 
-    if dsn:
+    if dsn and dsn.startswith(("edgedb://", "edgedbadmin://")):
         parsed = urllib.parse.urlparse(dsn)
 
         if parsed.scheme not in ('edgedb', 'edgedbadmin'):
+            if parsed.scheme == 'edgedbadmin':
+                warnings.warn(
+                    'The `edgedbadmin` scheme is deprecated and is scheduled '
+                    'to be removed. Admin socket should never be used in '
+                    'applications. Use command-line tool `edgedb` to setup '
+                    'proper credentials.',
+                    DeprecationWarning, 4)
             raise ValueError(
                 f'invalid DSN: scheme is expected to be '
                 f'"edgedb" or "edgedbadmin", got {parsed.scheme!r}')
@@ -177,6 +193,31 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                     server_settings = query
                 else:
                     server_settings = {**query, **server_settings}
+    elif dsn:
+        if not dsn.isidentifier():
+            raise ValueError(
+                f"dsn {dsn!r} is neither a edgedb:// URI "
+                f"nor valid instance name"
+            )
+        path = (pathlib.Path.home() /
+                '.edgedb' / 'credentials' / dsn + '.json')
+        try:
+            creds = credentials.read_credentials(path)
+        except Exception as e:
+            raise errors.ClientError(
+                f"cannot read credentials of instance {dsn!r}"
+            ) from e
+
+        if port is None:
+            port = creds['port']
+        if user is None:
+            user = creds['user']
+        if host is None and 'host' in creds:
+            host = creds['host']
+        if password is None and 'password' in creds:
+            password = creds['password']
+        if database is None and 'database' in creds:
+            database = creds['database']
 
     if not host:
         hostspec = os.environ.get('EDGEDB_HOST')

--- a/edgedb/credentials.py
+++ b/edgedb/credentials.py
@@ -1,0 +1,69 @@
+import os
+import typing
+import json
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
+
+
+class RequiredCredentials(TypedDict, total=True):
+    port: int
+    user: str
+
+
+class Credentials(RequiredCredentials, total=False):
+    host: typing.Optional[str]
+    password: typing.Optional[str]
+    database: typing.Optional[str]
+
+
+def read_credentials(path: os.PathLike) -> Credentials:
+    try:
+        with open(path, encoding='utf-8') as f:
+            credentials = json.load(f)
+        return validate_credentials(credentials)
+    except Exception as e:
+        raise RuntimeError(
+            f"cannot read credentials at {path}"
+        ) from e
+
+
+def validate_credentials(data: dict) -> Credentials:
+    port = data.get('port')
+    if port is None:
+        port = 5656
+    if not isinstance(port, int) or port < 1 or port > 65535:
+        raise ValueError("invalid `port` value")
+
+    user = data.get('user')
+    if user is None:
+        raise ValueError("`user` key is required")
+    if not isinstance(user, str):
+        raise ValueError("`user` must be a string")
+
+    result = {  # required keys
+        "user": user,
+        "port": port,
+    }
+
+    host = data.get('host')
+    if host is not None:
+        if not isinstance(host, str):
+            raise ValueError("`host` must be a string")
+        result['host'] = host
+
+    database = data.get('database')
+    if database is not None:
+        if not isinstance(database, str):
+            raise ValueError("`database` must be a string")
+        result['database'] = database
+
+    password = data.get('password')
+    if password is not None:
+        if not isinstance(password, str):
+            raise ValueError("`password` must be a string")
+        result['password'] = password
+
+    return result

--- a/edgedb/errors/__init__.py
+++ b/edgedb/errors/__init__.py
@@ -384,4 +384,3 @@ class InvalidArgumentError(QueryArgumentError):
 
 class NoDataError(ClientError):
     _code = 0x_FF_03_00_00
-

--- a/tests/credentials1.json
+++ b/tests/credentials1.json
@@ -1,0 +1,6 @@
+{
+  "port": 10702,
+  "user": "test3n",
+  "password": "lZTBy1RVCfOpBAOwSCwIyBIR",
+  "database": "test3n"
+}

--- a/tests/test_con_utils.py
+++ b/tests/test_con_utils.py
@@ -271,7 +271,12 @@ class TestConUtils(unittest.TestCase):
 
         {
             'dsn': 'pq:///dbname?host=/unix_sock/test&user=spam',
-            'error': (ValueError, 'invalid DSN')
+            'error': (
+                ValueError,
+                "dsn "
+                "'pq:///dbname\\?host=/unix_sock/test&user=spam' "
+                "is neither a edgedb:// URI nor valid instance name"
+            )
         },
 
         {
@@ -312,19 +317,6 @@ class TestConUtils(unittest.TestCase):
             'dsn': 'edgedbadmin://user@?host=%2Ftmp',
             'result': (
                 [os.path.join('/tmp', '.s.EDGEDB.admin.5656')],
-                {
-                    'user': 'user',
-                    'database': 'user',
-                },
-                {}
-            )
-        },
-
-        {
-            'dsn': 'edgedbadmin://user@?host=%2Ftmp',
-            'admin': False,
-            'result': (
-                [os.path.join('/tmp', '.s.EDGEDB.5656')],
                 {
                     'user': 'user',
                     'database': 'user',

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,52 @@
+import unittest
+from edgedb import credentials
+
+
+class TestCredentials(unittest.TestCase):
+
+    def test_read(self):
+        creds = credentials.read_credentials('tests/credentials1.json')
+        self.assertEqual(creds, {
+            'database': 'test3n',
+            'password': 'lZTBy1RVCfOpBAOwSCwIyBIR',
+            'port': 10702,
+            'user': 'test3n',
+        })
+
+    def test_empty(self):
+        with self.assertRaisesRegex(ValueError, '`user` key is required'):
+            credentials.validate_credentials({})
+
+    def test_port(self):
+        with self.assertRaisesRegex(ValueError, 'invalid `port` value'):
+            credentials.validate_credentials({
+                'user': 'u1',
+                'port': '1234',
+            })
+
+        with self.assertRaisesRegex(ValueError, 'invalid `port` value'):
+            credentials.validate_credentials({
+                'user': 'u1',
+                'port': 0,
+            })
+
+        with self.assertRaisesRegex(ValueError, 'invalid `port` value'):
+            credentials.validate_credentials({
+                'user': 'u1',
+                'port': -1,
+            })
+
+        with self.assertRaisesRegex(ValueError, 'invalid `port` value'):
+            credentials.validate_credentials({
+                'user': 'u1',
+                'port': 65536,
+            })
+
+    def test_extra_key(self):
+        creds = credentials.validate_credentials(dict(
+            user='user1',
+            some_extra_data='test',
+        ))
+        # extra keys are ignored for forward compatibility
+        # but aren't exported through validator
+        self.assertEqual(creds, {"user": "user1", "port": 5656})


### PR DESCRIPTION
This changes just the meaning of `dsn` positional argument. This is a part of what's discussed in https://github.com/edgedb/edgedb/discussions/1683 other things will follow in the next release.

This also deprecates `admin=True` parameter and `edgedbadmin` schema, as
they aren't needed if proper permissions are set up. And were introduced
mainly for command-line tools.

Supersedes #112 