### PR TITLE
Include test json files in the distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include docs *.py *.rst
 recursive-include examples *.py
-recursive-include tests *.py *.pem
+recursive-include tests *.py *.pem *.json
 recursive-include edgedb *.pyx *.pxd *.pxi *.py *.c *.h
 include LICENSE README.rst Makefile


### PR DESCRIPTION
Without this, installed-package tests would fail.