### PR TITLE
Readme - Prefix local_date query with cal module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Basic Usage
         conn.execute('''
             CREATE TYPE User {
                 CREATE REQUIRED PROPERTY name -> str;
-                CREATE PROPERTY dob -> local_date;
+                CREATE PROPERTY dob -> cal::local_date;
             }
         ''')
 
@@ -56,7 +56,7 @@ Basic Usage
         conn.query('''
             INSERT User {
                 name := <str>$name,
-                dob := <local_date>$dob
+                dob := <cal::local_date>$dob
             }
         ''', name='Bob', dob=datetime.date(1984, 3, 1))
 


### PR DESCRIPTION
Hi,

This is a very minor fix to the `local_date` type reference on the example queries from the README file.
Currently it fails with the following error:

```python
edgedb.errors.InvalidReferenceError: type 'default::local_date' does not exist
```
I was testing with `edbedb-python 0.10.0` and Alpha 5

Thanks for this project! 