### PR TITLE
[breaking]: Use `edgedb` as default user and database

### DIFF
--- a/.github/workflows/install-edgedb.sh
+++ b/.github/workflows/install-edgedb.sh
@@ -15,7 +15,7 @@ if [[ "${OS_NAME}" == macos* ]]; then
     _path=$(/usr/libexec/path_helper -s |
             sed -E -e 's/.*:([^:]+EdgeDB[^:]+):.*/\1/g')
 
-    echo ::add-path::${_path}
+    echo ${_path} >> $GITHUB_PATH
 
 elif [[ "${OS_NAME}" == ubuntu* ]]; then
     curl https://packages.edgedb.com/keys/edgedb.asc \

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -17,7 +17,6 @@
 #
 
 
-import getpass
 import os
 import platform
 import typing
@@ -261,7 +260,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
     if user is None:
         user = os.getenv('EDGEDB_USER')
         if not user:
-            user = getpass.getuser()
+            user = 'edgedb'
 
     if password is None:
         password = os.getenv('EDGEDB_PASSWORD')
@@ -270,7 +269,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
         database = os.getenv('EDGEDB_DATABASE')
 
     if database is None:
-        database = user
+        database = 'edgedb'
 
     if user is None:
         raise errors.InterfaceError(

--- a/tests/test_con_utils.py
+++ b/tests/test_con_utils.py
@@ -36,7 +36,7 @@ class TestConUtils(unittest.TestCase):
                 [("localhost", 5656)],
                 {
                     'user': 'user',
-                    'database': 'user',
+                    'database': 'edgedb',
                 },
                 {},
             )
@@ -294,7 +294,7 @@ class TestConUtils(unittest.TestCase):
                 [os.path.join('/tmp', '.s.EDGEDB.56226')],
                 {
                     'user': 'user',
-                    'database': 'user',
+                    'database': 'edgedb',
                 },
                 {}
             )
@@ -307,7 +307,7 @@ class TestConUtils(unittest.TestCase):
                 [os.path.join('/tmp', '.s.EDGEDB.admin.5656')],
                 {
                     'user': 'user',
-                    'database': 'user',
+                    'database': 'edgedb',
                 },
                 {}
             )
@@ -319,7 +319,7 @@ class TestConUtils(unittest.TestCase):
                 [os.path.join('/tmp', '.s.EDGEDB.admin.5656')],
                 {
                     'user': 'user',
-                    'database': 'user',
+                    'database': 'edgedb',
                 },
                 {}
             )
@@ -443,7 +443,7 @@ class TestConUtils(unittest.TestCase):
                 'host': 'abc',
                 'result': (
                     [('abc', 5656)],
-                    {'user': '__test__', 'database': '__test__'},
+                    {'user': '__test__', 'database': 'edgedb'},
                     {}
                 )
             })


### PR DESCRIPTION
This fixes tests against EdgeDB master