### PR TITLE
Fix potential memory leak with persistent task groups

### DIFF
--- a/edgedb/_taskgroup.py
+++ b/edgedb/_taskgroup.py
@@ -22,6 +22,7 @@ import functools
 import itertools
 import textwrap
 import traceback
+import weakref
 
 
 class TaskGroup:
@@ -38,7 +39,7 @@ class TaskGroup:
         self._loop = None
         self._parent_task = None
         self._parent_cancel_requested = False
-        self._tasks = set()
+        self._tasks = weakref.WeakSet()
         self._unfinished_tasks = 0
         self._errors = []
         self._base_error = None


### PR DESCRIPTION
I just discovered a potential memory leak issue because the task group internally stores references of all spawned tasks and never clears them in `_tasks` set.
This should not be a problem if the users of `TaskGroup` only uses it for short-lived asyncio tasks, but if they use it for a whole lifecycle of long-lived objects or the entire application, it would be a source of memory leak.

Changing `_tasks` to `weakref.WeakSet` automatically clears (weak) references to completed tasks, and this does not affect the behavior of the current `TaskGroup` implementation.

Please have a look in my personal fork's self-PR at achimnol/aiotools#21.
I've skipped adding test cases because there seems no place for `TaskGroup` test cases.
