### PR TITLE
RFC1004: `retry` method implementation

### DIFF
--- a/edgedb/__init__.py
+++ b/edgedb/__init__.py
@@ -112,6 +112,7 @@ from .errors import (
     ClientConnectionFailedError,
     ClientConnectionFailedTemporarilyError,
     ClientConnectionTimeoutError,
+    ClientConnectionClosedError,
     InterfaceError,
     QueryArgumentError,
     MissingArgumentError,

--- a/edgedb/_cluster.py
+++ b/edgedb/_cluster.py
@@ -198,6 +198,8 @@ class Cluster:
         conn_args = self.get_connect_args().copy()
         conn_args['host'] = str(self._runstate_dir)
         conn_args['admin'] = True
+        # startup of the database may take > 30 sec on github-actions
+        conn_args['wait_until_available'] = 120
         conn = self.connect(**conn_args)
 
         try:

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -222,7 +222,7 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
         @functools.wraps(func)
         def cleanup():
             res = func(*args, **kwargs)
-            if asyncio.isfuture(res) or asyncio.iscoroutine(res):
+            if inspect.isawaitable(res):
                 self.loop.run_until_complete(res)
         super().addCleanup(cleanup)
 

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -281,7 +281,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
                     'CONFIGURE SESSION SET __internal_testmode := true;'))
 
         if self.ISOLATED_METHODS:
-            self.xact = self.con.transaction()
+            self.xact = self.con.try_transaction()
             self.loop.run_until_complete(self.xact.start())
 
         if self.SETUP_METHOD:
@@ -338,9 +338,9 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
             if script:
                 # The setup is expected to contain a CREATE MIGRATION,
                 # which needs to be wrapped in a transaction.
-                tx = cls.con.transaction()
+                tx = cls.con.try_transaction()
                 cls.loop.run_until_complete(tx.start())
-                cls.loop.run_until_complete(cls.con.execute(script))
+                cls.loop.run_until_complete(tx.execute(script))
                 cls.loop.run_until_complete(tx.commit())
                 del tx
 

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -218,6 +218,14 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
                                 f'{expected_val!r})') from e
                 raise
 
+    def addCleanup(self, func, *args, **kwargs):
+        @functools.wraps(func)
+        def cleanup():
+            res = func(*args, **kwargs)
+            if asyncio.isfuture(res) or asyncio.iscoroutine(res):
+                self.loop.run_until_complete(res)
+        super().addCleanup(cleanup)
+
 
 class ClusterTestCase(TestCase):
 

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -80,9 +80,13 @@ class _AsyncIOConnectionImpl:
             protocol and protocol.connected
         )
 
-    async def connect(self, loop, addrs, config, params):
+    async def connect(self, loop, addrs, config, params, *,
+                      single_attempt=False):
         addr = None
-        max_time = time.monotonic() + config.wait_until_available
+        if single_attempt:
+            max_time = 0
+        else:
+            max_time = time.monotonic() + config.wait_until_available
         iteration = 1
 
         while True:
@@ -182,16 +186,17 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         for cb in self._log_listeners:
             self._loop.call_soon(cb, self._ensure_proxied(), msg)
 
-    async def ensure_connected(self):
+    async def ensure_connected(self, *, single_attempt=False):
         if not self._impl or self._impl.is_closed():
-            await self._reconnect()
+            await self._reconnect(single_attempt=single_attempt)
 
     # overriden by connection pool
-    async def _reconnect(self):
+    async def _reconnect(self, single_attempt=False):
         assert not self._borrowed_for, self._borrowed_for
         self._impl = _AsyncIOConnectionImpl()
         await self._impl.connect(self._loop, self._addrs,
-                                 self._config, self._params)
+                                 self._config, self._params,
+                                 single_attempt=single_attempt)
 
     async def _fetchall(
         self,

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -83,10 +83,11 @@ class _AsyncIOConnectionImpl:
     async def connect(self, loop, addrs, config, params, *,
                       single_attempt=False):
         addr = None
+        start = time.monotonic()
         if single_attempt:
             max_time = 0
         else:
-            max_time = time.monotonic() + config.wait_until_available
+            max_time = start + config.wait_until_available
         iteration = 1
 
         while True:
@@ -114,6 +115,8 @@ class _AsyncIOConnectionImpl:
                         con_utils.render_client_no_connection_error(
                             e,
                             addr,
+                            attempts=iteration,
+                            duration=time.monotonic() - start,
                         ))
                     raise nice_err from e.__cause__
                 else:

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -166,7 +166,7 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
                          query_cache=query_cache)
         self._loop = loop
         self._impl = None
-        self._borrow = None
+        self._borrowed_for = None
 
     def __repr__(self):
         if self.is_closed():
@@ -188,7 +188,7 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
 
     # overriden by connection pool
     async def _reconnect(self):
-        assert not self._borrow, self._borrow
+        assert not self._borrowed_for, self._borrowed_for
         self._impl = _AsyncIOConnectionImpl()
         await self._impl.connect(self._loop, self._addrs,
                                  self._config, self._params)
@@ -203,8 +203,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         __allow_capabilities__: typing.Optional[int]=None,
         **kwargs,
     ) -> datatypes.Set:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -231,8 +231,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         __allow_capabilities__: typing.Optional[int]=None,
         **kwargs,
     ) -> typing.Tuple[datatypes.Set, typing.Dict[int, bytes]]:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         return await self._impl._protocol.execute_anonymous(
@@ -255,8 +255,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         __limit__: int=0,
         **kwargs,
     ) -> datatypes.Set:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -272,8 +272,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         return result
 
     async def query(self, query: str, *args, **kwargs) -> datatypes.Set:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -287,8 +287,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         return result
 
     async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -303,8 +303,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         return result
 
     async def query_json(self, query: str, *args, **kwargs) -> str:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -319,8 +319,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
 
     async def _fetchall_json_elements(
             self, query: str, *args, **kwargs) -> typing.List[str]:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -334,8 +334,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
         return result
 
     async def query_one_json(self, query: str, *args, **kwargs) -> str:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         result, _ = await self._impl._protocol.execute_anonymous(
@@ -361,8 +361,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
             ...     FOR x IN {100, 200, 300} UNION INSERT MyType { a := x };
             ... ''')
         """
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
         await self._impl._protocol.simple_query(query)

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -30,6 +30,7 @@ from . import abstract
 from . import base_con
 from . import con_utils
 from . import errors
+from . import retry as _retry
 from . import transaction as _transaction
 from . import legacy_transaction
 
@@ -146,7 +147,7 @@ class _AsyncIOConnectionImpl:
         await pr.connect()
         self._transport = tr
         self._protocol = pr
-        self._adddr = addr
+        self._addr = addr
 
     async def execute(self, query):
         await self._protocol.simple_query(query)
@@ -379,6 +380,9 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
             DeprecationWarning, 2)
         return legacy_transaction.AsyncIOTransaction(
             self, isolation, readonly, deferrable)
+
+    def retry(self) -> _retry.AsyncIORetry:
+        return _retry.AsyncIORetry(self)
 
     def try_transaction(self) -> _transaction.AsyncIOTransaction:
         return _transaction.AsyncIOTransaction(self)

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -25,6 +25,7 @@ import warnings
 from . import abstract
 from . import asyncio_con
 from . import errors
+from . import transaction as _transaction
 
 from .datatypes import datatypes
 
@@ -656,6 +657,9 @@ class AsyncIOPool(abstract.AsyncIOExecutor):
 
     async def __aexit__(self, *exc):
         await self.aclose()
+
+    def try_transaction(self) -> _transaction.AsyncIOTransaction:
+        return _transaction.AsyncIOTransaction(self)
 
 
 class PoolAcquireContext:

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -26,6 +26,7 @@ from . import abstract
 from . import asyncio_con
 from . import errors
 from . import transaction as _transaction
+from . import retry as _retry
 
 from .datatypes import datatypes
 
@@ -660,6 +661,9 @@ class AsyncIOPool(abstract.AsyncIOExecutor):
 
     def try_transaction(self) -> _transaction.AsyncIOTransaction:
         return _transaction.AsyncIOTransaction(self)
+
+    def retry(self) -> _retry.AsyncIORetry:
+        return _retry.AsyncIORetry(self)
 
 
 class PoolAcquireContext:

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -44,13 +44,13 @@ class PoolConnection(asyncio_con.AsyncIOConnection):
         self._holder = None
         self._detached = False
 
-    async def _reconnect(self):
+    async def _reconnect(self, single_attempt=False):
         if self._detached:
             # initial connection
             raise errors.InterfaceError(
                 "the underlying connection has been released back to the pool"
             )
-        return await super()._reconnect()
+        return await super()._reconnect(single_attempt=single_attempt)
 
     def _detach(self):
         new_conn = self.__class__(

--- a/edgedb/base_con.py
+++ b/edgedb/base_con.py
@@ -30,8 +30,12 @@ from .protocol.protocol import QueryCodecsCache as _QueryCodecsCache
 BaseConnection_T = typing.TypeVar('BaseConnection_T', bound='BaseConnection')
 
 
+class BorrowReason:
+    TRANSACTION = 'transaction'
+
+
 BORROW_ERRORS = {
-    'transaction':
+    BorrowReason.TRANSACTION:
         "Connection object is borrowed for a transaction. "
         "Use the methods on transaction object instead.",
 }

--- a/edgedb/base_con.py
+++ b/edgedb/base_con.py
@@ -30,6 +30,17 @@ from .protocol.protocol import QueryCodecsCache as _QueryCodecsCache
 BaseConnection_T = typing.TypeVar('BaseConnection_T', bound='BaseConnection')
 
 
+BORROW_ERRORS = {
+    'transaction':
+        "Connection object is borrowed for the transaction. "
+        "Use the methods on transaction object instead.",
+}
+
+
+def borrow_error(condition):
+    raise errors.InterfaceError(BORROW_ERRORS[condition])
+
+
 class BaseConnection:
 
     def __init__(self, addrs, config, params, *,

--- a/edgedb/base_con.py
+++ b/edgedb/base_con.py
@@ -32,7 +32,7 @@ BaseConnection_T = typing.TypeVar('BaseConnection_T', bound='BaseConnection')
 
 BORROW_ERRORS = {
     'transaction':
-        "Connection object is borrowed for the transaction. "
+        "Connection object is borrowed for a transaction. "
         "Use the methods on transaction object instead.",
 }
 

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -158,20 +158,20 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
                          codecs_registry=codecs_registry,
                          query_cache=query_cache)
         self._impl = None
-        self._borrow = None
+        self._borrowed_for = None
 
     def ensure_connected(self):
         self._get_protocol()
 
     def _reconnect(self):
-        assert not self._borrow, self._borrow
+        assert not self._borrowed_for, self._borrowed_for
         self._impl = _BlockingIOConnectionImpl()
         self._impl.connect(self._addrs, self._config, self._params)
         assert self._impl._protocol
 
     def _get_protocol(self):
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             self._reconnect()
         return self._impl._protocol

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -52,9 +52,12 @@ class _BlockingIOConnectionImpl:
         self._addr = None
         self._protocol = None
 
-    def connect(self, addrs, config, params):
+    def connect(self, addrs, config, params, *, single_attempt=False):
         addr = None
-        max_time = time.monotonic() + config.wait_until_available
+        if single_attempt:
+            max_time = 0
+        else:
+            max_time = time.monotonic() + config.wait_until_available
         iteration = 1
 
         while True:
@@ -160,13 +163,17 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
         self._impl = None
         self._borrowed_for = None
 
-    def ensure_connected(self):
-        self._get_protocol()
+    def ensure_connected(self, single_attempt=False):
+        if self._borrowed_for:
+            raise base_con.borrow_error(self._borrowed_for)
+        if not self._impl or self._impl.is_closed():
+            self._reconnect(single_attempt=single_attempt)
 
-    def _reconnect(self):
+    def _reconnect(self, single_attempt=False):
         assert not self._borrowed_for, self._borrowed_for
         self._impl = _BlockingIOConnectionImpl()
-        self._impl.connect(self._addrs, self._config, self._params)
+        self._impl.connect(self._addrs, self._config, self._params,
+                           single_attempt=single_attempt)
         assert self._impl._protocol
 
     def _get_protocol(self):

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -29,6 +29,7 @@ from . import base_con
 from . import con_utils
 from . import errors
 from . import transaction as _transaction
+from . import retry as _retry
 from . import legacy_transaction
 
 from .datatypes import datatypes
@@ -332,9 +333,10 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
             self, isolation, readonly, deferrable)
 
     def try_transaction(self) -> _transaction.Transaction:
-        if self._borrow:
-            raise base_con.borrow_error(self._borrow)
         return _transaction.Transaction(self)
+
+    def retry(self) -> _retry.Retry:
+        return _retry.Retry(self)
 
     def close(self) -> None:
         if not self.is_closed():

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -54,10 +54,11 @@ class _BlockingIOConnectionImpl:
 
     def connect(self, addrs, config, params, *, single_attempt=False):
         addr = None
+        start = time.monotonic()
         if single_attempt:
             max_time = 0
         else:
-            max_time = time.monotonic() + config.wait_until_available
+            max_time = start + config.wait_until_available
         iteration = 1
 
         while True:
@@ -82,6 +83,8 @@ class _BlockingIOConnectionImpl:
                         con_utils.render_client_no_connection_error(
                             e,
                             addr,
+                            attempts=iteration,
+                            duration=time.monotonic() - start,
                         ))
                     raise nice_err from e.__cause__
                 else:

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -359,16 +359,18 @@ def parse_connect_arguments(*, dsn, host, port, user, password,
     return addrs, params, config
 
 
-def render_client_no_connection_error(prefix, addr):
+def render_client_no_connection_error(prefix, addr, attempts, duration):
     if isinstance(addr, str):
         msg = (
             f'{prefix}'
+            f'\n\tAfter {attempts} attempts in {duration} sec'
             f'\n\tIs the server running locally and accepting '
             f'\n\tconnections on Unix domain socket {addr!r}?'
         )
     else:
         msg = (
             f'{prefix}'
+            f'\n\tAfter {attempts} attempts in {duration} sec'
             f'\n\tIs the server running on host {addr[0]!r} '
             f'and accepting '
             f'\n\tTCP/IP connections on port {addr[1]}?'

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -363,14 +363,14 @@ def render_client_no_connection_error(prefix, addr, attempts, duration):
     if isinstance(addr, str):
         msg = (
             f'{prefix}'
-            f'\n\tAfter {attempts} attempts in {duration} sec'
+            f'\n\tAfter {attempts} attempts in {duration:.1f} sec'
             f'\n\tIs the server running locally and accepting '
             f'\n\tconnections on Unix domain socket {addr!r}?'
         )
     else:
         msg = (
             f'{prefix}'
-            f'\n\tAfter {attempts} attempts in {duration} sec'
+            f'\n\tAfter {attempts} attempts in {duration:.1f} sec'
             f'\n\tIs the server running on host {addr[0]!r} '
             f'and accepting '
             f'\n\tTCP/IP connections on port {addr[1]}?'

--- a/edgedb/errors/__init__.py
+++ b/edgedb/errors/__init__.py
@@ -88,6 +88,7 @@ __all__ = _base.__all__ + (  # type: ignore
     'ClientConnectionFailedError',
     'ClientConnectionFailedTemporarilyError',
     'ClientConnectionTimeoutError',
+    'ClientConnectionClosedError',
     'InterfaceError',
     'QueryArgumentError',
     'MissingArgumentError',
@@ -347,10 +348,12 @@ class TransactionError(ExecutionError):
 
 class TransactionSerializationError(TransactionError):
     _code = 0x_05_03_00_01
+    tags = frozenset({SHOULD_RETRY})
 
 
 class TransactionDeadlockError(TransactionError):
     _code = 0x_05_03_00_02
+    tags = frozenset({SHOULD_RETRY})
 
 
 class ConfigurationError(EdgeDBError):
@@ -387,12 +390,17 @@ class ClientConnectionFailedError(ClientConnectionError):
 
 class ClientConnectionFailedTemporarilyError(ClientConnectionFailedError):
     _code = 0x_FF_01_01_01
-    tags = frozenset({SHOULD_RECONNECT})
+    tags = frozenset({SHOULD_RECONNECT, SHOULD_RETRY})
 
 
 class ClientConnectionTimeoutError(ClientConnectionError):
     _code = 0x_FF_01_02_00
-    tags = frozenset({SHOULD_RECONNECT})
+    tags = frozenset({SHOULD_RECONNECT, SHOULD_RETRY})
+
+
+class ClientConnectionClosedError(ClientConnectionError):
+    _code = 0x_FF_01_03_00
+    tags = frozenset({SHOULD_RECONNECT, SHOULD_RETRY})
 
 
 class InterfaceError(ClientError):

--- a/edgedb/errors/tags.py
+++ b/edgedb/errors/tags.py
@@ -1,6 +1,7 @@
 __all__ = [
     'Tag',
     'SHOULD_RECONNECT',
+    'SHOULD_RETRY',
 ]
 
 
@@ -21,3 +22,4 @@ class Tag(object):
 
 
 SHOULD_RECONNECT = Tag('SHOULD_RECONNECT')
+SHOULD_RETRY = Tag('SHOULD_RETRY')

--- a/edgedb/legacy_transaction.py
+++ b/edgedb/legacy_transaction.py
@@ -18,13 +18,8 @@
 
 
 import enum
-import typing
 
-from . import abstract
-from . import base_con
 from . import errors
-from .datatypes import datatypes
-from .protocol import protocol
 
 
 __all__ = ('Transaction', 'AsyncIOTransaction')
@@ -44,10 +39,10 @@ ISOLATION_LEVELS = {'serializable', 'repeatable_read'}
 class BaseTransaction:
 
     __slots__ = ('_connection', '_isolation', '_readonly', '_deferrable',
-                 '_state', '_managed')
+                 '_state', '_nested', '_id', '_managed')
 
-    def __init__(self, connection, isolation: str = None,
-                 readonly: bool = None, deferrable: bool = None):
+    def __init__(self, connection, isolation: str,
+                 readonly: bool, deferrable: bool):
         if isolation is not None and isolation not in ISOLATION_LEVELS:
             raise ValueError(
                 'isolation is expected to be either of {}, '
@@ -58,6 +53,8 @@ class BaseTransaction:
         self._readonly = readonly
         self._deferrable = deferrable
         self._state = TransactionState.NEW
+        self._nested = False
+        self._id = None
         self._managed = False
 
     def is_active(self) -> bool:
@@ -91,32 +88,88 @@ class BaseTransaction:
             raise errors.InterfaceError(
                 'cannot start; the transaction is already started')
 
-        query = 'START TRANSACTION'
+        con = self._connection
 
-        if self._isolation == 'repeatable_read':
-            query = 'START TRANSACTION ISOLATION REPEATABLE READ'
-        elif self._isolation == 'serializable':
-            query = 'START TRANSACTION ISOLATION SERIALIZABLE'
+        if con._top_xact is None:
+            con._top_xact = self
+        else:
+            # Nested transaction block
+            top_xact = con._top_xact
+            if self._isolation is None:
+                self._isolation = top_xact._isolation
+            if self._readonly is None:
+                self._readonly = top_xact._readonly
+            if self._deferrable is None:
+                self._deferrable = top_xact._deferrable
 
-        if self._readonly:
-            query += ' READ ONLY'
-        elif self._readonly is not None:
-            query += ' READ WRITE'
-        if self._deferrable:
-            query += ' DEFERRABLE'
-        elif self._deferrable is not None:
-            query += ' NOT DEFERRABLE'
-        query += ';'
+            if self._isolation != top_xact._isolation:
+                raise errors.InterfaceError(
+                    'nested transaction has a different isolation level: '
+                    'current {!r} != outer {!r}'.format(
+                        self._isolation, top_xact._isolation))
+
+            if self._readonly != top_xact._readonly:
+                raise errors.InterfaceError(
+                    'nested transaction has a different read-write spec: '
+                    'current {!r} != outer {!r}'.format(
+                        self._readonly, top_xact._readonly))
+
+            if self._deferrable != top_xact._deferrable:
+                raise errors.InterfaceError(
+                    'nested transaction has a different deferrable spec: '
+                    'current {!r} != outer {!r}'.format(
+                        self._deferrable, top_xact._deferrable))
+
+            self._nested = True
+
+        if self._nested:
+            self._id = con._get_unique_id('savepoint')
+            query = f'DECLARE SAVEPOINT {self._id};'
+        else:
+            query = 'START TRANSACTION'
+
+            if self._isolation == 'repeatable_read':
+                query = 'START TRANSACTION ISOLATION REPEATABLE READ'
+            elif self._isolation == 'serializable':
+                query = 'START TRANSACTION ISOLATION SERIALIZABLE'
+
+            if self._readonly:
+                query += ' READ ONLY'
+            elif self._readonly is not None:
+                query += ' READ WRITE'
+            if self._deferrable:
+                query += ' DEFERRABLE'
+            elif self._deferrable is not None:
+                query += ' NOT DEFERRABLE'
+            query += ';'
 
         return query
 
     def _make_commit_query(self):
         self.__check_state('commit')
-        return 'COMMIT;'
+
+        if self._connection._top_xact is self:
+            self._connection._top_xact = None
+
+        if self._nested:
+            query = f'RELEASE SAVEPOINT {self._id};'
+        else:
+            query = 'COMMIT;'
+
+        return query
 
     def _make_rollback_query(self):
         self.__check_state('rollback')
-        return 'ROLLBACK;'
+
+        if self._connection._top_xact is self:
+            self._connection._top_xact = None
+
+        if self._nested:
+            query = f'ROLLBACK TO SAVEPOINT {self._id};'
+        else:
+            query = 'ROLLBACK;'
+
+        return query
 
     def __repr__(self):
         attrs = []
@@ -138,8 +191,7 @@ class BaseTransaction:
             mod, self.__class__.__name__, ' '.join(attrs), id(self))
 
 
-class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
-    __slots__ = ()
+class AsyncIOTransaction(BaseTransaction):
 
     async def __aenter__(self):
         if self._managed:
@@ -147,7 +199,6 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
                 'cannot enter context: already in an `async with` block')
         self._managed = True
         await self.start()
-        return self
 
     async def __aexit__(self, extype, ex, tb):
         try:
@@ -160,17 +211,14 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
 
     async def start(self) -> None:
         """Enter the transaction or savepoint block."""
-        query = self._make_start_query()
-        if self._connection._borrow:
-            raise base_con.borrow_error(self._connection._borrow)
         await self._connection.ensure_connected()
-        self._connection._borrow = 'transaction'
         self._connection_impl = self._connection._impl
+
+        query = self._make_start_query()
         try:
             await self._connection_impl.execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
-            self._connection._borrow = None
             raise
         else:
             self._state = TransactionState.STARTED
@@ -184,8 +232,6 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
             raise
         else:
             self._state = TransactionState.COMMITTED
-        finally:
-            self._connection._borrow = None
 
     async def __rollback(self):
         query = self._make_rollback_query()
@@ -196,8 +242,6 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
             raise
         else:
             self._state = TransactionState.ROLLEDBACK
-        finally:
-            self._connection._borrow = None
 
     async def commit(self) -> None:
         """Exit the transaction or savepoint block and commit changes."""
@@ -213,73 +257,8 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
                 'cannot manually rollback from within an `async with` block')
         await self.__rollback()
 
-    async def query(self, query: str, *args, **kwargs) -> datatypes.Set:
-        con = self._connection
-        result, _ = await self._connection_impl._protocol.execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            io_format=protocol.IoFormat.BINARY,
-        )
-        return result
 
-    async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
-        con = self._connection
-        result, _ = await self._connection_impl._protocol.execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            expect_one=True,
-            io_format=protocol.IoFormat.BINARY,
-        )
-        return result
-
-    async def query_json(self, query: str, *args, **kwargs) -> str:
-        con = self._connection
-        result, _ = await self._connection_impl._protocol.execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            io_format=protocol.IoFormat.JSON,
-        )
-        return result
-
-    async def query_one_json(self, query: str, *args, **kwargs) -> str:
-        con = self._connection
-        result, _ = await self._connection_impl._protocol.execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            expect_one=True,
-            io_format=protocol.IoFormat.JSON,
-        )
-        return result
-
-    async def execute(self, query: str) -> None:
-        """Execute an EdgeQL command (or commands).
-
-        Example:
-
-        .. code-block:: pycon
-
-            >>> await con.execute('''
-            ...     CREATE TYPE MyType { CREATE PROPERTY a -> int64 };
-            ...     FOR x IN {100, 200, 300} UNION INSERT MyType { a := x };
-            ... ''')
-        """
-        await self._connection_impl._protocol.simple_query(query)
-
-
-class Transaction(BaseTransaction, abstract.Executor):
-    __slots__ = ()
+class Transaction(BaseTransaction):
 
     def __enter__(self):
         if self._managed:
@@ -287,7 +266,6 @@ class Transaction(BaseTransaction, abstract.Executor):
                 'cannot enter context: already in a `with` block')
         self._managed = True
         self.start()
-        return self
 
     def __exit__(self, extype, ex, tb):
         try:
@@ -301,16 +279,12 @@ class Transaction(BaseTransaction, abstract.Executor):
     def start(self) -> None:
         """Enter the transaction or savepoint block."""
         query = self._make_start_query()
-        if self._connection._borrow:
-            raise base_con.borrow_error(self._connection._borrow)
         self._connection.ensure_connected()
-        self._connection._borrow = 'transaction'
         self._connection_impl = self._connection._impl
         try:
             self._connection_impl.execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
-            self._connection._borrow = None
             raise
         else:
             self._state = TransactionState.STARTED
@@ -324,8 +298,6 @@ class Transaction(BaseTransaction, abstract.Executor):
             raise
         else:
             self._state = TransactionState.COMMITTED
-        finally:
-            self._connection._borrow = None
 
     def __rollback(self):
         query = self._make_rollback_query()
@@ -336,8 +308,6 @@ class Transaction(BaseTransaction, abstract.Executor):
             raise
         else:
             self._state = TransactionState.ROLLEDBACK
-        finally:
-            self._connection._borrow = None
 
     def commit(self) -> None:
         """Exit the transaction or savepoint block and commit changes."""
@@ -352,52 +322,3 @@ class Transaction(BaseTransaction, abstract.Executor):
             raise errors.InterfaceError(
                 'cannot manually rollback from within a `with` block')
         self.__rollback()
-
-    def query(self, query: str, *args, **kwargs) -> datatypes.Set:
-        con = self._connection
-        return self._connection_impl._protocol.sync_execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            io_format=protocol.IoFormat.BINARY,
-        )
-
-    def query_one(self, query: str, *args, **kwargs) -> typing.Any:
-        con = self._connection
-        return self._connection_impl._protocol.sync_execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            expect_one=True,
-            io_format=protocol.IoFormat.BINARY,
-        )
-
-    def query_json(self, query: str, *args, **kwargs) -> str:
-        con = self._connection
-        return self._connection_impl._protocol.sync_execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            io_format=protocol.IoFormat.JSON,
-        )
-
-    def query_one_json(self, query: str, *args, **kwargs) -> str:
-        con = self._connection
-        return self._connection_impl._protocol.sync_execute_anonymous(
-            query=query,
-            args=args,
-            kwargs=kwargs,
-            reg=con._codecs_registry,
-            qc=con._query_cache,
-            expect_one=True,
-            io_format=protocol.IoFormat.JSON,
-        )
-
-    def execute(self, query: str) -> None:
-        self._connection_impl._protocol.sync_simple_query(query)

--- a/edgedb/legacy_transaction.py
+++ b/edgedb/legacy_transaction.py
@@ -15,7 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+This module provides support for legacy `connection.transaction()` method.
 
+This API is deprecated and will eventually be removed.
+Use `retry()` or `try_transaction()` instead.
+"""
 
 import enum
 

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -326,11 +326,11 @@ cdef class SansIOProtocol:
 
     cdef ensure_connected(self):
         if self.cancelled:
-            raise errors.ClientConnectionError(
+            raise errors.ClientConnectionCanceledError(
                 'the connection has been closed '
                 'because an operation was cancelled on it')
         if not self.connected:
-            raise errors.ClientConnectionError(
+            raise errors.ClientConnectionCanceledError(
                 'the connection has been closed')
 
     async def _execute(self, BaseCodec in_dc, BaseCodec out_dc, args, kwargs):

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -326,11 +326,11 @@ cdef class SansIOProtocol:
 
     cdef ensure_connected(self):
         if self.cancelled:
-            raise errors.ClientConnectionCanceledError(
+            raise errors.ClientConnectionClosedError(
                 'the connection has been closed '
                 'because an operation was cancelled on it')
         if not self.connected:
-            raise errors.ClientConnectionCanceledError(
+            raise errors.ClientConnectionClosedError(
                 'the connection has been closed')
 
     async def _execute(self, BaseCodec in_dc, BaseCodec out_dc, args, kwargs):

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -1,0 +1,87 @@
+import asyncio
+import random
+
+from . import errors
+from . import transaction as _transaction
+
+
+DEFAULT_MAX_ITERATIONS = 3
+
+
+def default_backoff(attempt):
+    return (2 ** attempt) * 0.1 + random.randrange(100) * 0.1
+
+
+class AsyncIOIteration(_transaction.AsyncIOTransaction):
+    def __init__(self, retry, owner):
+        super().__init__(owner)
+        self.__retry = retry
+
+    async def start(self):
+        if not self._managed:
+            raise errors.InterfaceError(
+                "Only managed retriable transactions are supported. "
+                "Use `async with transaction:`"
+            )
+        # TODO(tailhook) if this is not the first iteration suppress
+        # `wait_until_available` timeout
+        await super().start()
+
+    async def __aexit__(self, extype, ex, tb):
+        try:
+            await super().__aexit__(extype, ex, tb)
+        except errors.ClientConnectionClosedError as err:
+            if ex is None:
+                # TODO(tailhook) should we figure out if err is *caused by*
+                # CancelledError and propagate the latter instead or retrying?
+
+                # If we were going to commit, retry
+                if self.__retry._retry(err):
+                    return True
+                else:
+                    # if retries are exhausted we need to propagate this error
+                    raise err
+            # If we were going to rollback, look at original error
+            # to find out whether we want to retry, regardless of
+            # the rollback error.
+            # In this case we ignore rollback issue as original error is more
+            # important, e.g. in case `CancelledError` it's important
+            # to propagate it to cancel the whole task.
+
+        if (
+            extype is not None and
+            issubclass(extype, errors.EdgeDBError) and
+            ex.has_tag(errors.SHOULD_RETRY)
+        ):
+            return self.__retry._retry(ex)
+
+
+class AsyncIORetry:
+
+    def __init__(self, owner):
+        self._owner = owner
+        self._iteration = 0
+        self._done = False
+        self._backoff = default_backoff
+        self._max_iterations = DEFAULT_MAX_ITERATIONS
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._done:
+            raise StopAsyncIteration
+        assert self._iteration + 1 < self._max_iterations, \
+            f"Extra retry {self._iteration}/{self._max_iterations}"
+        if self._iteration > 0:
+            await asyncio.sleep(self._backoff(self._iteration))
+        self._iteration += 1
+        self._done = True
+        return AsyncIOIteration(self, self._owner)
+
+    def _retry(self, exc):
+        self._last_exception = exc
+        if self._iteration >= self._max_iterations:
+            return False
+        self._done = False
+        return True

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -91,7 +91,7 @@ class AsyncIORetry(BaseRetry):
         return iteration
 
 
-class Retry:
+class Retry(BaseRetry):
 
     def __iter__(self):
         return self

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -10,7 +10,7 @@ DEFAULT_MAX_ITERATIONS = 3
 
 
 def default_backoff(attempt):
-    return (2 ** attempt) * 0.1 + random.randrange(100) * 0.1
+    return (2 ** attempt) * 0.1 + random.randrange(100) * 0.001
 
 
 class AsyncIOIteration(_transaction.AsyncIOTransaction):

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import time
 
 from . import errors
 from . import transaction as _transaction
@@ -85,3 +86,77 @@ class AsyncIORetry:
             return False
         self._done = False
         return True
+
+
+class Retry:
+
+    def __init__(self, owner):
+        self._owner = owner
+        self._iteration = 0
+        self._done = False
+        self._backoff = default_backoff
+        self._max_iterations = DEFAULT_MAX_ITERATIONS
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._done:
+            raise StopIteration
+        assert self._iteration + 1 < self._max_iterations, \
+            f"Extra retry {self._iteration}/{self._max_iterations}"
+        if self._iteration > 0:
+            time.sleep(self._backoff(self._iteration))
+        self._iteration += 1
+        self._done = True
+        return Iteration(self, self._owner)
+
+    def _retry(self, exc):
+        self._last_exception = exc
+        if self._iteration >= self._max_iterations:
+            return False
+        self._done = False
+        return True
+
+
+class Iteration(_transaction.Transaction):
+    def __init__(self, retry, owner):
+        super().__init__(owner)
+        self.__retry = retry
+
+    def start(self):
+        if not self._managed:
+            raise errors.InterfaceError(
+                "Only managed retriable transactions are supported. "
+                "Use `with transaction:`"
+            )
+        # TODO(tailhook) if this is not the first iteration suppress
+        # `wait_until_available` timeout
+        super().start()
+
+    def __exit__(self, extype, ex, tb):
+        try:
+            super().__exit__(extype, ex, tb)
+        except errors.ClientConnectionClosedError as err:
+            if ex is None:
+                # TODO(tailhook) should we figure out if err is *caused by*
+                # CancelledError and propagate the latter instead or retrying?
+
+                # If we were going to commit, retry
+                if self.__retry._retry(err):
+                    return True
+                else:
+                    # if retries are exhausted we need to propagate this error
+                    raise err
+            # If we were going to rollback, look at original error
+            # to find out whether we want to retry, regardless of
+            # the rollback error.
+            # In this case we ignore rollback issue as original error is more
+            # important.
+
+        if (
+            extype is not None and
+            issubclass(extype, errors.EdgeDBError) and
+            ex.has_tag(errors.SHOULD_RETRY)
+        ):
+            return self.__retry._retry(ex)

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -36,6 +36,7 @@ class AsyncIOIteration(_transaction.AsyncIOTransaction):
                 # On commit we don't know if commit is succeeded before the
                 # database have received it or after it have been done but
                 # network is dropped before we were able to receive a response
+                # TODO(tailhook) retry on some errors
                 raise err
             # If we were going to rollback, look at original error
             # to find out whether we want to retry, regardless of

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -1,0 +1,121 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import asyncio
+
+import logging
+
+from edgedb import _testbase as tb
+
+log = logging.getLogger(__name__)
+
+
+class Barrier:
+    def __init__(self, number):
+        self._counter = number
+        self._cond = asyncio.Condition()
+
+    async def ready(self):
+        if self._counter == 0:
+            return
+        async with self._cond:
+            self._counter -= 1
+            assert self._counter >= 0, self._counter
+            if self._counter == 0:
+                self._cond.notify_all()
+            else:
+                await self._cond.wait_for(lambda: self._counter == 0)
+
+
+class TestAsyncRetry(tb.AsyncQueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    SETUP = '''
+        CREATE TYPE test::Counter EXTENDING std::Object {
+            CREATE PROPERTY name -> std::str {
+                CREATE CONSTRAINT std::exclusive;
+            };
+            CREATE PROPERTY value -> std::int32 {
+                SET default := 0;
+            };
+        };
+    '''
+
+    TEARDOWN = '''
+        DROP TYPE test::Counter;
+    '''
+
+    async def test_async_retry_01(self):
+        async for tx in self.con.retry():
+            async with tx:
+                await tx.execute('''
+                    INSERT test::Counter {
+                        name := 'counter1'
+                    };
+                ''')
+
+    async def test_async_retry_conflict(self):
+        con2 = await self.connect(database=self.get_database_name())
+        self.addCleanup(con2.aclose)
+
+        barrier = Barrier(2)
+        iterations = 0
+
+        async def transaction1(con):
+            async for tx in con.retry():
+                nonlocal iterations
+                iterations += 1
+                async with tx:
+                    # This magic query makes the test more reliable for some
+                    # reason. I guess this is because starting a transaction
+                    # in EdgeDB (and/or Postgres) is accomplished somewhat
+                    # lazily, i.e. only start transaction on the first query
+                    # rather than on the `START TRANSACTION`.
+                    await tx.query("SELECT 1")
+
+                    # Start both transactions at the same initial data.
+                    # One should succeed other should fail and retry.
+                    # On next attempt, the latter should succeed
+                    await barrier.ready()
+
+                    res = await tx.query_one('''
+                        SELECT (
+                            INSERT test::Counter {
+                                name := 'counter2',
+                                value := 1,
+                            } UNLESS CONFLICT ON .name
+                            ELSE (
+                                UPDATE test::Counter
+                                SET { value := .value + 1 }
+                            )
+                        ).value
+                    ''')
+            return res
+
+        results = await asyncio.wait_for(asyncio.gather(
+            transaction1(self.con),
+            transaction1(con2),
+            return_exceptions=True,
+        ), 10)
+        for e in results:
+            if isinstance(e, BaseException):
+                log.exception("Coroutine exception", exc_info=e)
+
+        self.assertEqual(set(results), {1, 2})
+        self.assertEqual(iterations, 3)

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -20,6 +20,7 @@ import asyncio
 
 import logging
 
+import edgedb
 from edgedb import _testbase as tb
 
 log = logging.getLogger(__name__)
@@ -119,3 +120,15 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
 
         self.assertEqual(set(results), {1, 2})
         self.assertEqual(iterations, 3)
+
+    async def test_async_transaction_interface_errors(self):
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*the transaction is already started'):
+            async for tx in self.con.retry():
+                async with tx:
+                    await tx.start()
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*Use `async with transaction:`'):
+            async for tx in self.con.retry():
+                await tx.start()

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -37,13 +37,13 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
     '''
 
     async def test_async_transaction_regular_01(self):
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
         tr = self.con.try_transaction()
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         with self.assertRaises(ZeroDivisionError):
             async with tr as with_tr:
-                self.assertIs(self.con._borrow, 'transaction')
+                self.assertIs(self.con._borrowed_for, 'transaction')
 
                 with self.assertRaisesRegex(edgedb.InterfaceError,
                                             '.*is borrowed.*'):
@@ -61,7 +61,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
                 1 / 0
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         result = await self.con.query('''
             SELECT
@@ -73,7 +73,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
         self.assertEqual(result, [])
 
     async def test_async_transaction_interface_errors(self):
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
@@ -84,14 +84,14 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
         self.assertTrue(repr(tr).startswith(
             '<edgedb.AsyncIOTransaction state:rolledback'))
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already rolled back'):
             async with tr:
                 pass
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
@@ -99,7 +99,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
             async with tr:
                 await tr.commit()
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
@@ -107,7 +107,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
             async with tr:
                 await tr.rollback()
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -37,20 +37,23 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
     '''
 
     async def test_async_transaction_regular_01(self):
-        self.assertIsNone(self.con._top_xact)
-        tr = self.con.transaction()
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
+        tr = self.con.try_transaction()
+        self.assertIsNone(self.con._borrow)
 
         with self.assertRaises(ZeroDivisionError):
             async with tr as with_tr:
-                self.assertIs(self.con._top_xact, tr)
+                self.assertIs(self.con._borrow, 'transaction')
 
-                # We don't return the transaction object from __aenter__,
-                # to make it harder for people to use '.rollback()' and
-                # '.commit()' from within an 'async with' block.
-                self.assertIsNone(with_tr)
+                with self.assertRaisesRegex(edgedb.InterfaceError,
+                                            '.*is borrowed.*'):
+                    await self.con.execute('''
+                        INSERT test::TransactionTest {
+                            name := 'Test Transaction'
+                        };
+                    ''')
 
-                await self.con.execute('''
+                await with_tr.execute('''
                     INSERT test::TransactionTest {
                         name := 'Test Transaction'
                     };
@@ -58,7 +61,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
                 1 / 0
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
         result = await self.con.query('''
             SELECT
@@ -69,94 +72,10 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
         self.assertEqual(result, [])
 
-    async def test_async_transaction_nested_01(self):
-        self.assertIsNone(self.con._top_xact)
-        tr = self.con.transaction()
-        self.assertIsNone(self.con._top_xact)
-
-        with self.assertRaises(ZeroDivisionError):
-            async with tr:
-                self.assertIs(self.con._top_xact, tr)
-
-                async with self.con.transaction():
-                    self.assertIs(self.con._top_xact, tr)
-
-                    await self.con.execute('''
-                        INSERT test::TransactionTest {
-                            name := 'TXTEST 1'
-                        };
-                    ''')
-
-                self.assertIs(self.con._top_xact, tr)
-
-                with self.assertRaises(ZeroDivisionError):
-                    in_tr = self.con.transaction()
-                    async with in_tr:
-
-                        self.assertIs(self.con._top_xact, tr)
-
-                        await self.con.execute('''
-                            INSERT test::TransactionTest {
-                                name := 'TXTEST 2'
-                            };
-                        ''')
-
-                        1 / 0
-
-                recs = await self.con.query('''
-                    SELECT
-                        test::TransactionTest {
-                            name
-                        }
-                    FILTER
-                        test::TransactionTest.name LIKE 'TXTEST%';
-                ''')
-
-                self.assertEqual(recs[0].name, 'TXTEST 1')
-                self.assertIs(self.con._top_xact, tr)
-
-                1 / 0
-
-        self.assertIs(self.con._top_xact, None)
-
-        recs = await self.con.query('''
-            SELECT
-                test::TransactionTest {
-                    name
-                }
-            FILTER
-                test::TransactionTest.name LIKE 'TXTEST%';
-        ''')
-
-        self.assertEqual(len(recs), 0)
-
-    async def test_async_transaction_nested_02(self):
-        async with self.con.transaction(isolation='repeatable_read'):
-            async with self.con.transaction():  # no explicit isolation, OK
-                pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different isolation'):
-            async with self.con.transaction(isolation='repeatable_read'):
-                async with self.con.transaction(isolation='serializable'):
-                    pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different read-write'):
-            async with self.con.transaction():
-                async with self.con.transaction(readonly=True):
-                    pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different deferrable'):
-            async with self.con.transaction(deferrable=True):
-                async with self.con.transaction(deferrable=False):
-                    pass
-
     async def test_async_transaction_interface_errors(self):
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already started'):
             async with tr:
@@ -165,34 +84,64 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
         self.assertTrue(repr(tr).startswith(
             '<edgedb.AsyncIOTransaction state:rolledback'))
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already rolled back'):
             async with tr:
                 pass
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually commit.*async with'):
             async with tr:
                 await tr.commit()
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually rollback.*async with'):
             async with tr:
                 await tr.rollback()
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot enter context:.*async with'):
             async with tr:
                 async with tr:
                     pass
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.query("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.query_one("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.query_json("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.query_one_json("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.execute("SELECT 1")

--- a/tests/test_async_tx_legacy.py
+++ b/tests/test_async_tx_legacy.py
@@ -1,0 +1,198 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import edgedb
+
+from edgedb import _testbase as tb
+
+
+class TestAsyncTxLegacy(tb.AsyncQueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    SETUP = '''
+        CREATE TYPE test::TransactionTest EXTENDING std::Object {
+            CREATE PROPERTY name -> std::str;
+        };
+    '''
+
+    TEARDOWN = '''
+        DROP TYPE test::TransactionTest;
+    '''
+
+    async def test_async_transaction_regular_01(self):
+        self.assertIsNone(self.con._top_xact)
+        tr = self.con.transaction()
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaises(ZeroDivisionError):
+            async with tr as with_tr:
+                self.assertIs(self.con._top_xact, tr)
+
+                # We don't return the transaction object from __aenter__,
+                # to make it harder for people to use '.rollback()' and
+                # '.commit()' from within an 'async with' block.
+                self.assertIsNone(with_tr)
+
+                await self.con.execute('''
+                    INSERT test::TransactionTest {
+                        name := 'Test Transaction'
+                    };
+                ''')
+
+                1 / 0
+
+        self.assertIsNone(self.con._top_xact)
+
+        result = await self.con.query('''
+            SELECT
+                test::TransactionTest
+            FILTER
+                test::TransactionTest.name = 'Test Transaction';
+        ''')
+
+        self.assertEqual(result, [])
+
+    async def test_async_transaction_nested_01(self):
+        self.assertIsNone(self.con._top_xact)
+        tr = self.con.transaction()
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaises(ZeroDivisionError):
+            async with tr:
+                self.assertIs(self.con._top_xact, tr)
+
+                async with self.con.transaction():
+                    self.assertIs(self.con._top_xact, tr)
+
+                    await self.con.execute('''
+                        INSERT test::TransactionTest {
+                            name := 'TXTEST 1'
+                        };
+                    ''')
+
+                self.assertIs(self.con._top_xact, tr)
+
+                with self.assertRaises(ZeroDivisionError):
+                    in_tr = self.con.transaction()
+                    async with in_tr:
+
+                        self.assertIs(self.con._top_xact, tr)
+
+                        await self.con.execute('''
+                            INSERT test::TransactionTest {
+                                name := 'TXTEST 2'
+                            };
+                        ''')
+
+                        1 / 0
+
+                recs = await self.con.query('''
+                    SELECT
+                        test::TransactionTest {
+                            name
+                        }
+                    FILTER
+                        test::TransactionTest.name LIKE 'TXTEST%';
+                ''')
+
+                self.assertEqual(recs[0].name, 'TXTEST 1')
+                self.assertIs(self.con._top_xact, tr)
+
+                1 / 0
+
+        self.assertIs(self.con._top_xact, None)
+
+        recs = await self.con.query('''
+            SELECT
+                test::TransactionTest {
+                    name
+                }
+            FILTER
+                test::TransactionTest.name LIKE 'TXTEST%';
+        ''')
+
+        self.assertEqual(len(recs), 0)
+
+    async def test_async_transaction_nested_02(self):
+        async with self.con.transaction(isolation='repeatable_read'):
+            async with self.con.transaction():  # no explicit isolation, OK
+                pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different isolation'):
+            async with self.con.transaction(isolation='repeatable_read'):
+                async with self.con.transaction(isolation='serializable'):
+                    pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different read-write'):
+            async with self.con.transaction():
+                async with self.con.transaction(readonly=True):
+                    pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different deferrable'):
+            async with self.con.transaction(deferrable=True):
+                async with self.con.transaction(deferrable=False):
+                    pass
+
+    async def test_async_transaction_interface_errors(self):
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot start; .* already started'):
+            async with tr:
+                await tr.start()
+
+        self.assertTrue(repr(tr).startswith(
+            '<edgedb.AsyncIOTransaction state:rolledback'))
+
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot start; .* already rolled back'):
+            async with tr:
+                pass
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot manually commit.*async with'):
+            async with tr:
+                await tr.commit()
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot manually rollback.*async with'):
+            async with tr:
+                await tr.rollback()
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot enter context:.*async with'):
+            async with tr:
+                async with tr:
+                    pass

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -240,6 +240,14 @@ class TestPool(tb.AsyncQueryTestCase):
 
         await pool.aclose()
 
+    async def test_pool_transaction(self):
+        pool = await self.create_pool(min_size=1, max_size=1)
+
+        async with pool.try_transaction() as tx:
+            self.assertEqual(await tx.query_one("SELECT 7*8"), 56)
+
+        await pool.aclose()
+
     def test_pool_init_run_until_complete(self):
         pool_init = self.create_pool()
         pool = self.loop.run_until_complete(pool_init)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -248,6 +248,15 @@ class TestPool(tb.AsyncQueryTestCase):
 
         await pool.aclose()
 
+    async def test_pool_retry(self):
+        pool = await self.create_pool(min_size=1, max_size=1)
+
+        async for tx in pool.retry():
+            async with tx:
+                self.assertEqual(await tx.query_one("SELECT 7*8"), 56)
+
+        await pool.aclose()
+
     def test_pool_init_run_until_complete(self):
         pool_init = self.create_pool()
         pool = self.loop.run_until_complete(pool_init)

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -1,0 +1,103 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import threading
+from concurrent import futures
+
+import edgedb
+from edgedb import _testbase as tb
+
+
+class TestSyncRetry(tb.SyncQueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    SETUP = '''
+        CREATE TYPE test::Counter EXTENDING std::Object {
+            CREATE PROPERTY name -> std::str {
+                CREATE CONSTRAINT std::exclusive;
+            };
+            CREATE PROPERTY value -> std::int32 {
+                SET default := 0;
+            };
+        };
+    '''
+
+    TEARDOWN = '''
+        DROP TYPE test::Counter;
+    '''
+
+    def test_sync_retry_01(self):
+        for tx in self.con.retry():
+            with tx:
+                tx.execute('''
+                    INSERT test::Counter {
+                        name := 'counter1'
+                    };
+                ''')
+
+    def test_sync_retry_conflict(self):
+        con_args = self.get_connect_args().copy()
+        con_args.update(database=self.get_database_name())
+        con2 = edgedb.connect(**con_args)
+        self.addCleanup(con2.close)
+
+        def mark_as_done():
+            nonlocal barrier_done
+            barrier_done = True
+
+        barrier_done = bool
+        barrier = threading.Barrier(2, timeout=10, action=mark_as_done)
+
+        iterations = 0
+
+        def transaction1(con):
+            for tx in con.retry():
+                nonlocal iterations, barrier_done
+                iterations += 1
+                with tx:
+
+                    # Start both transactions at the same initial data.
+                    # One should succeed other should fail and retry.
+                    # On next attempt, the latter should succeed
+                    # (and avoid barrier)
+                    if not barrier_done:
+                        barrier.wait()
+
+                    res = tx.query_one('''
+                        SELECT (
+                            INSERT test::Counter {
+                                name := 'counter2',
+                                value := 1,
+                            } UNLESS CONFLICT ON .name
+                            ELSE (
+                                UPDATE test::Counter
+                                SET { value := .value + 1 }
+                            )
+                        ).value
+                    ''')
+            return res
+
+        with futures.ThreadPoolExecutor(2) as pool:
+            f1 = pool.submit(transaction1, self.con)
+            f2 = pool.submit(transaction1, con2)
+            results = {f1.result(), f2.result()}
+
+        self.assertEqual(results, {1, 2})
+        self.assertEqual(iterations, 3)

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -17,7 +17,6 @@
 #
 
 
-import collections
 import threading
 from concurrent import futures
 

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -69,6 +69,22 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                     };
                 ''')
 
+    def test_async_retry_02(self):
+        with self.assertRaises(ZeroDivisionError):
+            for tx in self.con.retry():
+                with tx:
+                    tx.execute('''
+                        INSERT test::Counter {
+                            name := 'counter_retry_02'
+                        };
+                    ''')
+                    1 / 0
+        with self.assertRaises(edgedb.NoDataError):
+            self.con.query_one('''
+                SELECT test::Counter
+                FILTER .name = 'counter_retry_02'
+            ''')
+
     def test_sync_retry_conflict(self):
         con_args = self.get_connect_args().copy()
         con_args.update(database=self.get_database_name())

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -117,3 +117,15 @@ class TestSyncRetry(tb.SyncQueryTestCase):
 
         self.assertEqual(results, {1, 2})
         self.assertEqual(iterations, 3)
+
+    def test_sync_transaction_interface_errors(self):
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*the transaction is already started'):
+            for tx in self.con.retry():
+                with tx:
+                    tx.start()
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*Use `with transaction:`'):
+            for tx in self.con.retry():
+                tx.start()

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -92,6 +92,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
         self.addCleanup(con2.close)
 
         barrier = Barrier(2)
+        lock = threading.Lock()
 
         iterations = 0
 
@@ -112,6 +113,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                     # On next attempt, the latter should succeed
                     barrier.ready()
 
+                    lock.acquire()
                     res = tx.query_one('''
                         SELECT (
                             INSERT test::Counter {
@@ -124,6 +126,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                             )
                         ).value
                     ''')
+                lock.release()
             return res
 
         with futures.ThreadPoolExecutor(2) as pool:

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -37,20 +37,13 @@ class TestSyncTx(tb.SyncQueryTestCase):
     '''
 
     def test_sync_transaction_regular_01(self):
-        self.assertIsNone(self.con._top_xact)
-        tr = self.con.transaction()
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
+        tr = self.con.try_transaction()
+        self.assertIsNone(self.con._borrow)
 
         with self.assertRaises(ZeroDivisionError):
             with tr as with_tr:
-                self.assertIs(self.con._top_xact, tr)
-
-                # We don't return the transaction object from __aenter__,
-                # to make it harder for people to use '.rollback()' and
-                # '.commit()' from within an 'with' block.
-                self.assertIsNone(with_tr)
-
-                self.con.execute('''
+                with_tr.execute('''
                     INSERT test::TransactionTest {
                         name := 'Test Transaction'
                     };
@@ -58,7 +51,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
                 1 / 0
 
-        self.assertIsNone(self.con._top_xact)
+        self.assertIsNone(self.con._borrow)
 
         result = self.con.query('''
             SELECT
@@ -69,95 +62,10 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertEqual(result, [])
 
-    def test_sync_transaction_nested_01(self):
-        self.assertIsNone(self.con._top_xact)
-        tr = self.con.transaction()
-        self.assertIsNone(self.con._top_xact)
-
-        with self.assertRaises(ZeroDivisionError):
-            with tr:
-                self.assertIs(self.con._top_xact, tr)
-
-                with self.con.transaction():
-                    self.assertIs(self.con._top_xact, tr)
-
-                    self.con.execute('''
-                        INSERT test::TransactionTest {
-                            name := 'TXTEST 1'
-                        };
-                    ''')
-
-                self.assertIs(self.con._top_xact, tr)
-
-                with self.assertRaises(ZeroDivisionError):
-                    in_tr = self.con.transaction()
-                    with in_tr:
-
-                        self.assertIs(self.con._top_xact, tr)
-
-                        self.con.query('''
-                            INSERT test::TransactionTest {
-                                name := 'TXTEST 2'
-                            };
-                        ''')
-
-                        1 / 0
-
-                recs = self.con.query('''
-                    SELECT
-                        test::TransactionTest {
-                            name
-                        }
-                    FILTER
-                        test::TransactionTest.name LIKE 'TXTEST%';
-                ''')
-
-                self.assertEqual(len(recs), 1)
-                self.assertEqual(recs[0].name, 'TXTEST 1')
-                self.assertIs(self.con._top_xact, tr)
-
-                1 / 0
-
-        self.assertIs(self.con._top_xact, None)
-
-        recs = self.con.query('''
-            SELECT
-                test::TransactionTest {
-                    name
-                }
-            FILTER
-                test::TransactionTest.name LIKE 'TXTEST%';
-        ''')
-
-        self.assertEqual(len(recs), 0)
-
-    def test_sync_transaction_nested_02(self):
-        with self.con.transaction(isolation='repeatable_read'):
-            with self.con.transaction():  # no explicit isolation, OK
-                pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different isolation'):
-            with self.con.transaction(isolation='repeatable_read'):
-                with self.con.transaction(isolation='serializable'):
-                    pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different read-write'):
-            with self.con.transaction():
-                with self.con.transaction(readonly=True):
-                    pass
-
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'different deferrable'):
-            with self.con.transaction(deferrable=True):
-                with self.con.transaction(deferrable=False):
-                    pass
-
     def test_sync_transaction_interface_errors(self):
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already started'):
             with tr:
@@ -175,7 +83,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually commit.*with'):
             with tr:
@@ -183,7 +91,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually rollback.*with'):
             with tr:
@@ -191,9 +99,39 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.transaction()
+        tr = self.con.try_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot enter context:.*with'):
             with tr:
                 with tr:
                     pass
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.query("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.query_one("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.query_json("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.query_one_json("SELECT 1")
+
+        tr = self.con.try_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.execute("SELECT 1")

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -37,9 +37,9 @@ class TestSyncTx(tb.SyncQueryTestCase):
     '''
 
     def test_sync_transaction_regular_01(self):
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
         tr = self.con.try_transaction()
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         with self.assertRaises(ZeroDivisionError):
             with tr as with_tr:
@@ -51,7 +51,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
                 1 / 0
 
-        self.assertIsNone(self.con._borrow)
+        self.assertIsNone(self.con._borrowed_for)
 
         result = self.con.query('''
             SELECT

--- a/tests/test_sync_tx_legacy.py
+++ b/tests/test_sync_tx_legacy.py
@@ -1,0 +1,199 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import edgedb
+
+from edgedb import _testbase as tb
+
+
+class TestSyncTxLegacy(tb.SyncQueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    SETUP = '''
+        CREATE TYPE test::TransactionTest EXTENDING std::Object {
+            CREATE PROPERTY name -> std::str;
+        };
+    '''
+
+    TEARDOWN = '''
+        DROP TYPE test::TransactionTest;
+    '''
+
+    def test_sync_transaction_regular_01(self):
+        self.assertIsNone(self.con._top_xact)
+        tr = self.con.transaction()
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaises(ZeroDivisionError):
+            with tr as with_tr:
+                self.assertIs(self.con._top_xact, tr)
+
+                # We don't return the transaction object from __aenter__,
+                # to make it harder for people to use '.rollback()' and
+                # '.commit()' from within an 'with' block.
+                self.assertIsNone(with_tr)
+
+                self.con.execute('''
+                    INSERT test::TransactionTest {
+                        name := 'Test Transaction'
+                    };
+                ''')
+
+                1 / 0
+
+        self.assertIsNone(self.con._top_xact)
+
+        result = self.con.query('''
+            SELECT
+                test::TransactionTest
+            FILTER
+                test::TransactionTest.name = 'Test Transaction';
+        ''')
+
+        self.assertEqual(result, [])
+
+    def test_sync_transaction_nested_01(self):
+        self.assertIsNone(self.con._top_xact)
+        tr = self.con.transaction()
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaises(ZeroDivisionError):
+            with tr:
+                self.assertIs(self.con._top_xact, tr)
+
+                with self.con.transaction():
+                    self.assertIs(self.con._top_xact, tr)
+
+                    self.con.execute('''
+                        INSERT test::TransactionTest {
+                            name := 'TXTEST 1'
+                        };
+                    ''')
+
+                self.assertIs(self.con._top_xact, tr)
+
+                with self.assertRaises(ZeroDivisionError):
+                    in_tr = self.con.transaction()
+                    with in_tr:
+
+                        self.assertIs(self.con._top_xact, tr)
+
+                        self.con.query('''
+                            INSERT test::TransactionTest {
+                                name := 'TXTEST 2'
+                            };
+                        ''')
+
+                        1 / 0
+
+                recs = self.con.query('''
+                    SELECT
+                        test::TransactionTest {
+                            name
+                        }
+                    FILTER
+                        test::TransactionTest.name LIKE 'TXTEST%';
+                ''')
+
+                self.assertEqual(len(recs), 1)
+                self.assertEqual(recs[0].name, 'TXTEST 1')
+                self.assertIs(self.con._top_xact, tr)
+
+                1 / 0
+
+        self.assertIs(self.con._top_xact, None)
+
+        recs = self.con.query('''
+            SELECT
+                test::TransactionTest {
+                    name
+                }
+            FILTER
+                test::TransactionTest.name LIKE 'TXTEST%';
+        ''')
+
+        self.assertEqual(len(recs), 0)
+
+    def test_sync_transaction_nested_02(self):
+        with self.con.transaction(isolation='repeatable_read'):
+            with self.con.transaction():  # no explicit isolation, OK
+                pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different isolation'):
+            with self.con.transaction(isolation='repeatable_read'):
+                with self.con.transaction(isolation='serializable'):
+                    pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different read-write'):
+            with self.con.transaction():
+                with self.con.transaction(readonly=True):
+                    pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'different deferrable'):
+            with self.con.transaction(deferrable=True):
+                with self.con.transaction(deferrable=False):
+                    pass
+
+    def test_sync_transaction_interface_errors(self):
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot start; .* already started'):
+            with tr:
+                tr.start()
+
+        self.assertTrue(repr(tr).startswith(
+            '<edgedb.Transaction state:rolledback'))
+
+        self.assertIsNone(self.con._top_xact)
+
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot start; .* already rolled back'):
+            with tr:
+                pass
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot manually commit.*with'):
+            with tr:
+                tr.commit()
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot manually rollback.*with'):
+            with tr:
+                tr.rollback()
+
+        self.assertIsNone(self.con._top_xact)
+
+        tr = self.con.transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'cannot enter context:.*with'):
+            with tr:
+                with tr:
+                    pass


### PR DESCRIPTION
This is the most basic implementation, i.e. it might not handle some cases of network errors. But it provides the needed API to handle that.