### PR TITLE
Disable "transaction" capability when using `execute()`

### DIFF
--- a/edgedb/_cluster.py
+++ b/edgedb/_cluster.py
@@ -196,7 +196,7 @@ class Cluster:
         conn_args['host'] = str(self._runstate_dir)
         conn_args['admin'] = True
         # startup of the database may take > 30 sec on github-actions
-        conn_args['wait_until_available'] = 120
+        conn_args['wait_until_available'] = 240
         conn = self.connect(**conn_args)
 
         try:

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -31,6 +31,7 @@ from . import base_con
 from . import compat
 from . import con_utils
 from . import errors
+from . import enums
 from . import retry as _retry
 from . import transaction as _transaction
 from . import legacy_transaction
@@ -68,10 +69,12 @@ def _extract_errno(s):
 
 class _AsyncIOConnectionImpl:
 
-    def __init__(self):
+    def __init__(self, codecs_registry, query_cache):
         self._addr = None
         self._transport = None
         self._protocol = None
+        self._codecs_registry = codecs_registry
+        self._query_cache = query_cache
 
     def is_closed(self):
         transport = self._transport
@@ -158,8 +161,8 @@ class _AsyncIOConnectionImpl:
         self._protocol = pr
         self._addr = addr
 
-    async def execute(self, query):
-        await self._protocol.simple_query(query)
+    async def privileged_execute(self, query):
+        await self._protocol.simple_query(query, enums.Capability.ALL)
 
     def close(self):
         if self._protocol:
@@ -198,7 +201,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
     # overriden by connection pool
     async def _reconnect(self, single_attempt=False):
         assert not self._borrowed_for, self._borrowed_for
-        self._impl = _AsyncIOConnectionImpl()
+        self._impl = _AsyncIOConnectionImpl(
+            self._codecs_registry, self._query_cache)
         await self._impl.connect(self._loop, self._addrs,
                                  self._config, self._params,
                                  single_attempt=single_attempt,
@@ -376,7 +380,8 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
             raise base_con.borrow_error(self._borrowed_for)
         if not self._impl or self._impl.is_closed():
             await self._reconnect()
-        await self._impl._protocol.simple_query(query)
+        await self._impl._protocol.simple_query(
+            query, enums.Capability.EXECUTE)
 
     def transaction(
         self, *,

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -27,6 +27,7 @@ import warnings
 from . import abstract
 from . import base_con
 from . import con_utils
+from . import enums
 from . import errors
 from . import transaction as _transaction
 from . import retry as _retry
@@ -48,9 +49,11 @@ TEMPORARY_ERRORS = frozenset({
 
 class _BlockingIOConnectionImpl:
 
-    def __init__(self):
+    def __init__(self, codecs_registry, query_cache):
         self._addr = None
         self._protocol = None
+        self._codecs_registry = codecs_registry
+        self._query_cache = query_cache
 
     def connect(self, addrs, config, params, *,
                 single_attempt=False, connection):
@@ -145,8 +148,8 @@ class _BlockingIOConnectionImpl:
             sock.close()
             raise
 
-    def execute(self, query: str) -> None:
-        self._protocol.sync_simple_query(query)
+    def privileged_execute(self, query):
+        self._protocol.sync_simple_query(query, enums.Capability.ALL)
 
     def is_closed(self):
         proto = self._protocol
@@ -176,7 +179,8 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
 
     def _reconnect(self, single_attempt=False):
         assert not self._borrowed_for, self._borrowed_for
-        self._impl = _BlockingIOConnectionImpl()
+        self._impl = _BlockingIOConnectionImpl(
+            self._codecs_registry, self._query_cache)
         self._impl.connect(self._addrs, self._config, self._params,
                            single_attempt=single_attempt, connection=self)
         assert self._impl._protocol
@@ -332,7 +336,7 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
         return self.query_one_json(query, *args, **kwargs)
 
     def execute(self, query: str) -> None:
-        self._get_protocol().sync_simple_query(query)
+        self._get_protocol().sync_simple_query(query, enums.Capability.EXECUTE)
 
     def transaction(self, *, isolation: str = None, readonly: bool = None,
                     deferrable: bool = None) -> legacy_transaction.Transaction:

--- a/edgedb/enums.py
+++ b/edgedb/enums.py
@@ -1,0 +1,14 @@
+import enum
+
+
+class Capability(enum.IntFlag):
+
+    MODIFICATIONS     = 1 << 0    # noqa
+    SESSION_CONFIG    = 1 << 1    # noqa
+    TRANSACTION       = 1 << 2    # noqa
+    DDL               = 1 << 3    # noqa
+    PERSISTENT_CONFIG = 1 << 4    # noqa
+
+
+Capability.ALL = 0xFFFF_FFFF_FFFF_FFFF
+Capability.EXECUTE = Capability.ALL & ~Capability.TRANSACTION

--- a/edgedb/legacy_transaction.py
+++ b/edgedb/legacy_transaction.py
@@ -221,7 +221,7 @@ class AsyncIOTransaction(BaseTransaction):
 
         query = self._make_start_query()
         try:
-            await self._connection_impl.execute(query)
+            await self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise
@@ -231,7 +231,7 @@ class AsyncIOTransaction(BaseTransaction):
     async def __commit(self):
         query = self._make_commit_query()
         try:
-            await self._connection_impl.execute(query)
+            await self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise
@@ -241,7 +241,7 @@ class AsyncIOTransaction(BaseTransaction):
     async def __rollback(self):
         query = self._make_rollback_query()
         try:
-            await self._connection_impl.execute(query)
+            await self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise
@@ -287,7 +287,7 @@ class Transaction(BaseTransaction):
         self._connection.ensure_connected()
         self._connection_impl = self._connection._impl
         try:
-            self._connection_impl.execute(query)
+            self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise
@@ -297,7 +297,7 @@ class Transaction(BaseTransaction):
     def __commit(self):
         query = self._make_commit_query()
         try:
-            self._connection_impl.execute(query)
+            self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise
@@ -307,7 +307,7 @@ class Transaction(BaseTransaction):
     def __rollback(self):
         query = self._make_rollback_query()
         try:
-            self._connection_impl.execute(query)
+            self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
             raise

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -33,6 +33,7 @@ class TestPool(tb.AsyncQueryTestCase):
     def create_pool(self, **kwargs):
         conargs = self.get_connect_args().copy()
         conargs["database"] = self.con.dbname
+        conargs["timeout"] = 120
         conargs.update(kwargs)
 
         return edgedb.create_async_pool(**conargs)


### PR DESCRIPTION
Currently `test_async_wait_cancel_01` fails. Looks like this is a bug of edgedb.