### PR TITLE
Fixes for tests

### DIFF
--- a/edgedb/_cluster.py
+++ b/edgedb/_cluster.py
@@ -94,7 +94,7 @@ class Cluster:
 
     @staticmethod
     def get_edgedb_server():
-        return 'edgedb-server'
+        return os.environ.get('EDGEDB_SERVER_BINARY', 'edgedb-server')
 
     def get_status(self):
         data_dir = pathlib.Path(self._data_dir)

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -28,6 +28,7 @@ import warnings
 
 from . import abstract
 from . import base_con
+from . import compat
 from . import con_utils
 from . import errors
 from . import retry as _retry
@@ -93,7 +94,7 @@ class _AsyncIOConnectionImpl:
         while True:
             for addr in addrs:
                 try:
-                    await asyncio.wait_for(
+                    await compat.wait_for(
                         self._connect_addr(loop, addr, params, connection),
                         config.connect_timeout,
                     )

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -24,6 +24,7 @@ import warnings
 
 from . import abstract
 from . import asyncio_con
+from . import compat
 from . import errors
 from . import transaction as _transaction
 from . import retry as _retry
@@ -528,7 +529,7 @@ class AsyncIOPool(abstract.AsyncIOExecutor):
         if timeout is None:
             return await _acquire_impl()
         else:
-            return await asyncio.wait_for(
+            return await compat.wait_for(
                 _acquire_impl(), timeout=timeout)
 
     async def release(self, connection):

--- a/edgedb/compat.py
+++ b/edgedb/compat.py
@@ -1,0 +1,55 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import asyncio
+import sys
+
+
+if sys.version_info < (3, 7):
+    # Workaround for https://bugs.python.org/issue37658
+    import functools
+
+    async def _cancel_and_wait(fut):
+        def _release_waiter(waiter, *args):
+            if not waiter.done():
+                waiter.set_result(None)
+
+        waiter = asyncio.get_event_loop().create_future()
+        cb = functools.partial(_release_waiter, waiter)
+        fut.add_done_callback(cb)
+
+        try:
+            fut.cancel()
+            await waiter
+        finally:
+            fut.remove_done_callback(cb)
+
+    async def wait_for(fut, timeout):
+        fut = asyncio.ensure_future(fut)
+
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            if fut.done():
+                return fut.result()
+            else:
+                await _cancel_and_wait(fut)
+                raise
+
+else:
+    wait_for = asyncio.wait_for

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 
 import edgedb
+from edgedb import compat
 from edgedb import _testbase as tb
 
 log = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                 lock.release()
             return res
 
-        results = await asyncio.wait_for(asyncio.gather(
+        results = await compat.wait_for(asyncio.gather(
             transaction1(self.con),
             transaction1(con2),
             return_exceptions=True,

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -52,6 +52,7 @@ class TestConnect(tb.AsyncQueryTestCase):
         orig_conn_args = self.get_connect_args()
         conn_args = orig_conn_args.copy()
         conn_args['port'] = self.port
+        conn_args['wait_until_available'] = 0
 
         with self.assertRaisesRegex(
                 edgedb.ClientConnectionError,


### PR DESCRIPTION
There are a number of issues:

- `asyncio.wait_for()` is very buggy in Python 3.6, so backport
  fixes from newer Pythons as a wrapper and use it everywhere;
- There was a single `sys::sleep` user which wasn't adjusted
  to use `sys::_sleep` (and also lacked a skip guard);
- The `test_async_wait_cancel_01` test had a bug in it: it used the
  wrong connection instance.

Fixes: #160.