### PR TITLE
Make sure aclose() waits for the server to close the connection

### DIFF
--- a/edgedb/protocol/asyncio_proto.pxd
+++ b/edgedb/protocol/asyncio_proto.pxd
@@ -28,6 +28,7 @@ cdef class AsyncIOProtocol(protocol.SansIOProtocol):
         object transport
 
         object connected_fut
+        object disconnected_fut
 
         object loop
         object msg_waiter

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -32,12 +32,17 @@ class TestProto(tb.SyncQueryTestCase):
             self.con.query_json('SELECT {"aaa", "bbb"}'),
             '["aaa", "bbb"]')
 
-    @unittest.skip  # not merged into edgedb yet
     def test_json_elements(self):
         self.assertEqual(
             self.con._fetchall_json_elements('SELECT {"aaa", "bbb"}'),
             edgedb.Set(['"aaa"', '"bbb"']))
 
+    # std::datetime is now in range of Python datetime,
+    # so another way to trigger codec failure is needed.
+    @unittest.skip("""
+        std::datetime is now in range of Python date,
+        so another way to trigger codec failure is needed.
+    """)
     async def test_proto_codec_error_recovery_01(self):
         for _ in range(5):  # execute a few times for OE
             with self.assertRaisesRegex(
@@ -58,6 +63,10 @@ class TestProto(tb.SyncQueryTestCase):
                 self.con.query('SELECT {"aaa", "bbb"}'),
                 ['aaa', 'bbb'])
 
+    @unittest.skip("""
+        std::date is now in range of Python date,
+        so another way to trigger codec failure is needed.
+    """)
     async def test_proto_codec_error_recovery_02(self):
         for _ in range(5):  # execute a few times for OE
             with self.assertRaisesRegex(


### PR DESCRIPTION
The point of the `aclose()` and the reason why it's a coroutine is to wait
for the server to close the connection.  This is known as graceful
disconnect, as opposed to a fast disconnect via `terminate()`.

Graceful disconnects are especially useful for cases when an agreement
on the state of the server after the disconnect is important, such as
when the script runs `DROP DATABASE` immediately after disconnecting.
If the disconnect is not negotiated properly, there is a possibility
that the server still thinks the connection is open and so a `DROP
DATABASE` operation would fail complaining that the database is still
being accessed.