### PR TITLE
Implement reading project config

### DIFF
--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -123,6 +123,8 @@ def _parse_hostlist(hostlist, port):
 
 def _stash_path(path):
     path = os.path.realpath(path)
+    if _system == 'Windows' and not path.startswith('\\\\'):
+        path = '\\\\?\\' + path
     hash = hashlib.sha1(path.encode('utf-8')).hexdigest()
     base_name = os.path.basename(path)
     dir_name = base_name + '-' + hash


### PR DESCRIPTION
Details:
1. Uses current directory for project dir
2. Does not search of the ancestor directories (unlike CLI tool)
3. Now crashes if `edgedb.toml` not found and no parameters specified

Also includes implementation of `EDGEDB_INSTANCE` env var support