### PR TITLE
Bump Cython to 0.29.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ from setuptools.command import build_py as setuptools_build_py
 from setuptools.command import sdist as setuptools_sdist
 
 
-CYTHON_DEPENDENCY = 'Cython==0.29.21'
+CYTHON_DEPENDENCY = 'Cython==0.29.23'
 
 # Minimal dependencies required to test edgedb.
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
Bump Cython dependency to 0.29.23 to pick up the latest fixes.