### PR TITLE
Rename --tls-cert-file to --tls-ca-file

### DIFF
--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -113,15 +113,14 @@ def _start_cluster(*, cleanup_atexit=True):
             raise RuntimeError('server status file not found')
 
         data = json.loads(line.split(b'READY=')[1])
-        con = edgedb.connect(
-            host='localhost', port=data['port'], password='test')
+        con_args = dict(host='localhost', port=data['port'])
+        if 'tls_cert_file' in data:
+            con_args['tls_ca_file'] = data['tls_cert_file']
+        con = edgedb.connect(password='test', **con_args)
         _default_cluster = {
             'proc': p,
             'con': con,
-            'con_args': {
-                'host': 'localhost',
-                'port': data['port'],
-            }
+            'con_args': con_args,
         }
         atexit.register(con.close)
     except Exception as e:

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -502,7 +502,7 @@ async def async_connect(dsn: str = None, *,
                         user: str = None, password: str = None,
                         admin: bool = None,
                         database: str = None,
-                        tls_cert_file: str = None,
+                        tls_ca_file: str = None,
                         tls_verify_hostname: bool = None,
                         connection_class=None,
                         wait_until_available: int = 30,
@@ -516,7 +516,7 @@ async def async_connect(dsn: str = None, *,
     addrs, params, config = con_utils.parse_connect_arguments(
         dsn=dsn, host=host, port=port, user=user, password=password,
         database=database, admin=admin, timeout=timeout,
-        tls_cert_file=tls_cert_file, tls_verify_hostname=tls_verify_hostname,
+        tls_ca_file=tls_ca_file, tls_verify_hostname=tls_verify_hostname,
         wait_until_available=wait_until_available,
 
         # ToDos

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -416,7 +416,7 @@ def connect(dsn: str = None, *,
             user: str = None, password: str = None,
             admin: bool = None,
             database: str = None,
-            tls_cert_file: str = None,
+            tls_ca_file: str = None,
             tls_verify_hostname: bool = None,
             timeout: int = 10,
             wait_until_available: int = 30) -> BlockingIOConnection:
@@ -426,7 +426,7 @@ def connect(dsn: str = None, *,
         database=database, admin=admin,
         timeout=timeout,
         wait_until_available=wait_until_available,
-        tls_cert_file=tls_cert_file, tls_verify_hostname=tls_verify_hostname,
+        tls_ca_file=tls_ca_file, tls_verify_hostname=tls_verify_hostname,
 
         # ToDos
         command_timeout=None,

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -145,10 +145,10 @@ def _parse_verify_hostname(val: str) -> typing.Optional[bool]:
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                                 password, database, admin,
-                                tls_cert_file, tls_verify_hostname,
+                                tls_ca_file, tls_verify_hostname,
                                 connect_timeout, server_settings):
     using_credentials = False
-    tls_cert_data = None
+    tls_ca_data = None
 
     if admin:
         warnings.warn(
@@ -256,10 +256,10 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 if password is None:
                     password = val
 
-            if 'tls_cert_file' in query:
-                val = query.pop('tls_cert_file')
-                if tls_cert_file is None:
-                    tls_cert_file = val
+            if 'tls_ca_file' in query:
+                val = query.pop('tls_ca_file')
+                if tls_ca_file is None:
+                    tls_ca_file = val
 
             if 'tls_verify_hostname' in query:
                 val = query.pop('tls_verify_hostname')
@@ -297,8 +297,8 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
             password = creds['password']
         if database is None and 'database' in creds:
             database = creds['database']
-        if tls_cert_file is None and 'tls_cert_data' in creds:
-            tls_cert_data = creds['tls_cert_data']
+        if tls_ca_file is None and 'tls_cert_data' in creds:
+            tls_ca_data = creds['tls_cert_data']
         if tls_verify_hostname is None and 'tls_verify_hostname' in creds:
             tls_verify_hostname = creds['tls_verify_hostname']
 
@@ -397,9 +397,9 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
     else:
         ssl_ctx = ssl.SSLContext()
         ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-        if tls_cert_file or tls_cert_data:
+        if tls_ca_file or tls_ca_data:
             ssl_ctx.load_verify_locations(
-                cafile=tls_cert_file, cadata=tls_cert_data
+                cafile=tls_ca_file, cadata=tls_ca_data
             )
             if tls_verify_hostname is None:
                 tls_verify_hostname = False
@@ -427,7 +427,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
 
 def parse_connect_arguments(*, dsn, host, port, user, password,
                             database, admin,
-                            tls_cert_file, tls_verify_hostname,
+                            tls_ca_file, tls_verify_hostname,
                             timeout, command_timeout, wait_until_available,
                             server_settings):
 
@@ -448,7 +448,7 @@ def parse_connect_arguments(*, dsn, host, port, user, password,
         dsn=dsn, host=host, port=port, user=user,
         password=password, admin=admin,
         database=database, connect_timeout=timeout,
-        tls_cert_file=tls_cert_file, tls_verify_hostname=tls_verify_hostname,
+        tls_ca_file=tls_ca_file, tls_verify_hostname=tls_verify_hostname,
         server_settings=server_settings,
     )
 

--- a/tests/test_con_utils.py
+++ b/tests/test_con_utils.py
@@ -378,7 +378,7 @@ class TestConUtils(unittest.TestCase):
         host = testcase.get('host')
         password = testcase.get('password')
         database = testcase.get('database')
-        tls_cert_file = testcase.get('tls_cert_file')
+        tls_ca_file = testcase.get('tls_ca_file')
         tls_verify_hostname = testcase.get('tls_verify_hostname')
         admin = testcase.get('admin')
         timeout = testcase.get('timeout')
@@ -407,7 +407,7 @@ class TestConUtils(unittest.TestCase):
             addrs, params, config = con_utils.parse_connect_arguments(
                 dsn=dsn, host=host, port=port, user=user, password=password,
                 database=database, admin=admin,
-                tls_cert_file=tls_cert_file,
+                tls_ca_file=tls_ca_file,
                 tls_verify_hostname=tls_verify_hostname,
                 timeout=timeout, command_timeout=command_timeout,
                 server_settings=server_settings,
@@ -520,7 +520,7 @@ class TestConUtils(unittest.TestCase):
                 addrs, params, _config = con_utils.parse_connect_arguments(
                     dsn=None, host=None, port=None, user=None, password=None,
                     database=None, admin=None,
-                    tls_cert_file=None, tls_verify_hostname=None,
+                    tls_ca_file=None, tls_verify_hostname=None,
                     timeout=10, command_timeout=None,
                     server_settings=None,
                     wait_until_available=30)


### PR DESCRIPTION
@fmoor if this is approved, we'd need the Go and JS bindings aligned.

Also fixed tests running on the new server, locally passed.

There will be another PR after we have the explicit option to generate dev certs on the server.