### PR TITLE
tests: Hide server output by default

### DIFF
--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -96,7 +96,18 @@ def _start_cluster(*, cleanup_atexit=True):
         # not interfere with the server's.
         env.pop('PYTHONPATH', None)
 
-        p = subprocess.Popen(args, env=env, cwd=tmpdir.name)
+        if env.get('EDGEDB_DEBUG_SERVER'):
+            server_stdout = None
+        else:
+            server_stdout = subprocess.DEVNULL
+
+        p = subprocess.Popen(
+            args,
+            env=env,
+            cwd=tmpdir.name,
+            stdout=server_stdout,
+            stderr=subprocess.STDOUT,
+        )
 
         for _ in range(250):
             try:


### PR DESCRIPTION
Point server output to `/dev/null` unless `EDGEDB_DEBUG_SERVER`
environment variable is set.