### PR TITLE
Use new server with --generate-self-signed-cert

### DIFF
--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -85,6 +85,7 @@ def _start_cluster(*, cleanup_atexit=True):
             f"--emit-server-status={status_file_unix}",
             "--port=auto",
             "--auto-shutdown",
+            "--generate-self-signed-cert",
             "--bootstrap-command=ALTER ROLE edgedb { SET password := 'test' }",
         ]
 

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -78,16 +78,20 @@ def _start_cluster(*, cleanup_atexit=True):
             .lower()
         )
 
+        edgedb_server = os.environ.get('EDGEDB_SERVER_BINARY', 'edgedb-server')
         args = [
-            os.environ.get('EDGEDB_SERVER_BINARY', 'edgedb-server'),
+            edgedb_server,
             "--temp-dir",
             "--testmode",
             f"--emit-server-status={status_file_unix}",
             "--port=auto",
             "--auto-shutdown",
-            "--generate-self-signed-cert",
             "--bootstrap-command=ALTER ROLE edgedb { SET password := 'test' }",
         ]
+        if "--generate-self-signed-cert" in subprocess.getoutput(
+            [edgedb_server, "--help"],
+        ):
+            args.append("--generate-self-signed-cert")
 
         if sys.platform == 'win32':
             args = ['wsl', '-u', 'edgedb'] + args


### PR DESCRIPTION
Depends on edgedb/edgedb#2680

I have manually tested this locally with the server on edgedb/edgedb#2680 and the test is a pass. I haven't tested CI but I think it should work once we have the new server nightly. (We could add a generate-cert option to the setup-edgedb action later).