### PR TITLE
edgedb-python v0.16.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.15.0'
+__version__ = '0.16.0'


### PR DESCRIPTION
Changes
=======

* Support binary protocol version 0.11 (#195)
  (by @fmoor in 8dd41fda for #195)

* Update typing-extensions (#196)
  (by @msullivan in 93d28f4b for #196)

* Use system config dir instead of ~/.edgedb (#197)
  (by @fantix in a44bf6a1 for #197)

* RFC 1008: Support TLS and ALPN (#198)
  (by @fantix in f1d8583a for #198)