### PR TITLE
Fix failing tests regarding --help

### DIFF
--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -52,6 +52,14 @@ def silence_asyncio_long_exec_warning():
         logger.removeFilter(flt)
 
 
+def _get_wsl_path(win_path):
+    return (
+        re.sub(r'^([A-Z]):', lambda m: f'/mnt/{m.group(1)}', win_path)
+        .replace("\\", '/')
+        .lower()
+    )
+
+
 _default_cluster = None
 
 
@@ -72,11 +80,7 @@ def _start_cluster(*, cleanup_atexit=True):
         status_file = os.path.join(tmpdir.name, 'server-status')
 
         # if running on windows adjust the path for WSL
-        status_file_unix = (
-            re.sub(r'^([A-Z]):', lambda m: f'/mnt/{m.group(1)}', status_file)
-            .replace("\\", '/')
-            .lower()
-        )
+        status_file_unix = _get_wsl_path(status_file)
 
         env = os.environ.copy()
         # Make sure the PYTHONPATH of _this_ process does
@@ -141,13 +145,34 @@ def _start_cluster(*, cleanup_atexit=True):
         data = json.loads(line.split(b'READY=')[1])
         con_args = dict(host='localhost', port=data['port'])
         if 'tls_cert_file' in data:
-            con_args['tls_ca_file'] = data['tls_cert_file']
+            if sys.platform == 'win32':
+                con_args['tls_ca_file'] = os.path.join(
+                    tmpdir.name, "edbtlscert.pem"
+                )
+                subprocess.check_call(
+                    [
+                        'wsl',
+                        '-u',
+                        'edgedb',
+                        'cp',
+                        data['tls_cert_file'],
+                        _get_wsl_path(con_args['tls_ca_file'])
+                    ]
+                )
+            else:
+                con_args['tls_ca_file'] = data['tls_cert_file']
+
         con = edgedb.connect(password='test', **con_args)
         _default_cluster = {
             'proc': p,
             'con': con,
             'con_args': con_args,
         }
+
+        if 'tls_cert_file' in data:
+            # Keep the temp dir which we also copied the cert from WSL
+            _default_cluster['_tmpdir'] = tmpdir
+
         atexit.register(con.close)
     except Exception as e:
         _default_cluster = e


### PR DESCRIPTION
`shell=True` seems to be the problem of the weird behavior on different environments. Also the `PYTHONPATH` was stopping the `--help` to import the correct uvloop. There was also a typo for Windows.

Also, the cert path in WSL is not directly translated into a path accessible from the host, so had to copy the cert to the tmpdir in the host on Windows.