### PR TITLE
Fix confusing error when no arguments are passed to a query with named params

### DIFF
--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -1112,7 +1112,7 @@ cdef class SansIOProtocol:
             (<NamedTupleCodec>in_dc).encode_kwargs(buf, kwargs)
 
         else:
-            if type(in_dc) is not TupleCodec:
+            if type(in_dc) is not TupleCodec and args:
                 raise errors.QueryArgumentError(
                     'expected named arguments, got positional arguments')
             in_dc.encode(buf, args)


### PR DESCRIPTION
Currently, if one attempts to execute a query with named parameters
without passing any arguments at all, they'll get a confusing `expected
named arguments, got positional arguments`.  Fix this to have the server
issue the appropriate error about argument counts instead.  See
edgedb/edgedb#1427.