### PR TITLE
More reliable transport double-closing

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -166,13 +166,6 @@ class _AsyncIOConnectionImpl:
             try:
                 self._protocol.terminate()
                 await self._protocol.wait_for_disconnect()
-
-                # With asyncio on CPython 3.10 or lower, a normal exit
-                # (connection closed by peer) cannot set the transport._closed
-                # properly, leading to false ResourceWarning. Let's fix that by
-                # closing the transport again.
-                if not self._transport.is_closing():
-                    self._transport.close()
             except (Exception, asyncio.CancelledError):
                 self.terminate()
                 raise

--- a/edgedb/protocol/asyncio_proto.pyx
+++ b/edgedb/protocol/asyncio_proto.pyx
@@ -112,6 +112,12 @@ cdef class AsyncIOProtocol(protocol.SansIOProtocol):
             self.msg_waiter.set_exception(ConnectionResetError())
             self.msg_waiter = None
 
+        # With asyncio sslproto on CPython 3.10 or lower, a normal exit
+        # (connection closed by peer) cannot set the transport._closed
+        # properly, leading to false ResourceWarning. Let's fix that by
+        # closing the transport again.
+        if not self.transport.is_closing():
+            self.transport.close()
         self.transport = None
 
     def pause_writing(self):


### PR DESCRIPTION
CRF for #210 - moved the double-closing logic to protocol.connection_lost() so that it's always executed.

Sample run: https://github.com/fantix/edgedb/actions/runs/1105120578