### PR TITLE
Stop pinning to an exact version of Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ from setuptools.command import build_py as setuptools_build_py
 from setuptools.command import sdist as setuptools_sdist
 
 
-CYTHON_DEPENDENCY = 'Cython==0.29.23'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Minimal dependencies required to test edgedb.
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
Cython 0.29 is in maintenance mode, so the risk of big breakage is low.
On the other hand, this maintenance picks up important fixes, including
support for newer Pythons.  Furthermore, pinning to an exact version
may cause conflicts if something else pins to a slightly different version.