### PR TITLE
rename query_one to query_single

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -105,7 +105,7 @@ Connection
         >>> import edgedb
         >>> async def main():
         ...     con = await edgedb.async_connect(user='edgedeb')
-        ...     print(await con.query_one('SELECT 1 + 1'))
+        ...     print(await con.query_single('SELECT 1 + 1'))
         ...
         >>> asyncio.run(main())
         {2}
@@ -134,7 +134,7 @@ Connection
         Note that positional and named query arguments cannot be mixed.
 
 
-    .. py:coroutinemethod:: query_one(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single(query, *args, **kwargs)
 
         Run a singleton-returning query and return its element.
 
@@ -179,7 +179,7 @@ Connection
             more appropriate type, such as ``Decimal``.
 
 
-    .. py:coroutinemethod:: query_one_json(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single_json(query, *args, **kwargs)
 
         Run a singleton-returning query and return its element in JSON.
 
@@ -232,7 +232,7 @@ Connection
 
         .. note::
             If the results of *query* are desired, :py:meth:`query` or
-            :py:meth:`query_one` should be used instead.
+            :py:meth:`query_single` should be used instead.
 
     .. py:method:: retrying_transaction()
 
@@ -254,7 +254,7 @@ Connection
 
             async for tx in con.retrying_transaction():
                 async with tx:
-                    value = await tx.query_one("SELECT Counter.value")
+                    value = await tx.query_single("SELECT Counter.value")
                     await tx.execute(
                         "UPDATE Counter SET { value := <int64>$value }",
                         value=value + 1,
@@ -282,7 +282,7 @@ Connection
         .. code-block:: python
 
             async with con.raw_transaction() as tx:
-                value = await tx.query_one("SELECT Counter.value")
+                value = await tx.query_single("SELECT Counter.value")
                 await tx.execute(
                     "UPDATE Counter SET { value := <int64>$value }",
                     value=value + 1,
@@ -368,9 +368,9 @@ Connection Pools
     from the pool:
 
     * :py:meth:`AsyncIOPool.query()`
-    * :py:meth:`AsyncIOPool.query_one()`
+    * :py:meth:`AsyncIOPool.query_single()`
     * :py:meth:`AsyncIOPool.query_json()`
-    * :py:meth:`AsyncIOPool.query_one_json()`
+    * :py:meth:`AsyncIOPool.query_single_json()`
     * :py:meth:`AsyncIOPool.execute()`
     * :py:meth:`AsyncIOPool.retrying_transaction()`
     * :py:meth:`AsyncIOPool.raw_transaction()`
@@ -505,14 +505,14 @@ Connection Pools
         See :py:meth:`AsyncIOConnection.query()
         <edgedb.AsyncIOConnection.query>` for details.
 
-    .. py:coroutinemethod:: query_one(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single(query, *args, **kwargs)
 
         Acquire a connection and use it to run a singleton-returning query
         and return its element. The temporary connection is automatically
         returned back to the pool.
 
-        See :py:meth:`AsyncIOConnection.query_one()
-        <edgedb.AsyncIOConnection.query_one>` for details.
+        See :py:meth:`AsyncIOConnection.query_single()
+        <edgedb.AsyncIOConnection.query_single>` for details.
 
     .. py:coroutinemethod:: query_json(query, *args, **kwargs)
 
@@ -523,14 +523,14 @@ Connection Pools
         See :py:meth:`AsyncIOConnection.query_json()
         <edgedb.AsyncIOConnection.query_json>` for details.
 
-    .. py:coroutinemethod:: query_one_json(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single_json(query, *args, **kwargs)
 
         Acquire a connection and use it to run a singleton-returning
         query and return its element in JSON. The temporary connection is
         automatically returned back to the pool.
 
-        See :py:meth:`AsyncIOConnection.query_one_json()
-        <edgedb.AsyncIOConnection.query_one_json>` for details.
+        See :py:meth:`AsyncIOConnection.query_single_json()
+        <edgedb.AsyncIOConnection.query_single_json>` for details.
 
     .. py:coroutinemethod:: execute(query)
 
@@ -561,7 +561,7 @@ Connection Pools
 
             async for tx in pool.retrying_transaction():
                 async with tx:
-                    value = await tx.query_one("SELECT Counter.value")
+                    value = await tx.query_single("SELECT Counter.value")
                     await tx.execute(
                         "UPDATE Counter SET { value := <int64>$value",
                         value=value,
@@ -589,7 +589,7 @@ Connection Pools
         .. code-block:: python
 
             async with pool.raw_transaction() as tx:
-                value = await tx.query_one("SELECT Counter.value")
+                value = await tx.query_single("SELECT Counter.value")
                 await tx.execute(
                     "UPDATE Counter SET { value := <int64>$value",
                     value=value,
@@ -635,7 +635,7 @@ Python code. Here is an example:
 
     async for tx in pool.retrying_transaction():
         async with tx:
-            user = await tx.query_one(
+            user = await tx.query_single(
                 "SELECT User { email } FILTER .login = <str>$login",
                 login=login,
             )
@@ -643,7 +643,7 @@ Python code. Here is an example:
                 'https://service.local/email_info',
                 params=dict(email=user.email),
             )
-            user = await tx.query_one('''
+            user = await tx.query_single('''
                     UPDATE User FILTER .login = <str>$login
                     SET { email_info := <json>$data}
                 ''',
@@ -707,14 +707,14 @@ See also:
         See :py:meth:`AsyncIOConnection.query()
         <edgedb.AsyncIOConnection.query>` for details.
 
-    .. py:coroutinemethod:: query_one(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single(query, *args, **kwargs)
 
         Acquire a connection and use it to run a singleton-returning query
         and return its element. The temporary connection is automatically
         returned back to the pool.
 
-        See :py:meth:`AsyncIOConnection.query_one()
-        <edgedb.AsyncIOConnection.query_one>` for details.
+        See :py:meth:`AsyncIOConnection.query_single()
+        <edgedb.AsyncIOConnection.query_single>` for details.
 
     .. py:coroutinemethod:: query_json(query, *args, **kwargs)
 
@@ -725,14 +725,14 @@ See also:
         See :py:meth:`AsyncIOConnection.query_json()
         <edgedb.AsyncIOConnection.query_json>` for details.
 
-    .. py:coroutinemethod:: query_one_json(query, *args, **kwargs)
+    .. py:coroutinemethod:: query_single_json(query, *args, **kwargs)
 
         Acquire a connection and use it to run a singleton-returning
         query and return its element in JSON. The temporary connection is
         automatically returned back to the pool.
 
-        See :py:meth:`AsyncIOConnection.query_one_json()
-        <edgedb.AsyncIOConnection.query_one_json>` for details.
+        See :py:meth:`AsyncIOConnection.query_single_json()
+        <edgedb.AsyncIOConnection.query_single_json>` for details.
 
     .. py:coroutinemethod:: execute(query)
 

--- a/docs/api/blocking_con.rst
+++ b/docs/api/blocking_con.rst
@@ -103,7 +103,7 @@ Connection
 
         >>> import edgedb
         >>> con = edgedb.connect(user='edgedeb')
-        >>> con.query_one('SELECT 1 + 1')
+        >>> con.query_single('SELECT 1 + 1')
         {2}
 
 
@@ -130,7 +130,7 @@ Connection
         Note that positional and named query arguments cannot be mixed.
 
 
-    .. py:method:: query_one(query, *args, **kwargs)
+    .. py:method:: query_single(query, *args, **kwargs)
 
         Run a singleton-returning query and return its element.
 
@@ -175,7 +175,7 @@ Connection
             more appropriate type, such as ``Decimal``.
 
 
-    .. py:method:: query_one_json(query, *args, **kwargs)
+    .. py:method:: query_single_json(query, *args, **kwargs)
 
         Run a singleton-returning query and return its element in JSON.
 
@@ -228,7 +228,7 @@ Connection
 
         .. note::
             If the results of *query* are desired, :py:meth:`query` or
-            :py:meth:`query_one` should be used instead.
+            :py:meth:`query_single` should be used instead.
 
     .. py:method:: retrying_transaction()
 
@@ -250,7 +250,7 @@ Connection
 
             for tx in con.retrying_transaction():
                 with tx:
-                    value = tx.query_one("SELECT Counter.value")
+                    value = tx.query_single("SELECT Counter.value")
                     tx.execute(
                         "UPDATE Counter SET { value := <int64>$value }",
                         value=value + 1,
@@ -278,7 +278,7 @@ Connection
         .. code-block:: python
 
             with con.raw_transaction() as tx:
-                value = tx.query_one("SELECT Counter.value")
+                value = tx.query_single("SELECT Counter.value")
                 tx.execute(
                     "UPDATE Counter SET { value := <int64>$value }",
                     value=value + 1,
@@ -355,7 +355,7 @@ Python code. Here is an example:
 
     for tx in pool.retrying_transaction():
         with tx:
-            user = tx.query_one(
+            user = tx.query_single(
                 "SELECT User { email } FILTER .login = <str>$login",
                 login=login,
             )
@@ -363,7 +363,7 @@ Python code. Here is an example:
                 'https://service.local/email_info',
                 params=dict(email=user.email),
             )
-            user = tx.query_one('''
+            user = tx.query_single('''
                     UPDATE User FILTER .login = <str>$login
                     SET { email_info := <json>$data}
                 ''',

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -113,7 +113,7 @@ Objects
 
         >>> import edgedb
         >>> conn = edgedb.connect()
-        >>> r = conn.query_one('''
+        >>> r = conn.query_single('''
         ...     SELECT schema::ObjectType {name}
         ...     FILTER .name = 'std::Object'
         ...     LIMIT 1''')
@@ -134,7 +134,7 @@ Objects
 
           >>> import edgedb
           >>> conn = edgedb.connect()
-          >>> r = conn.query_one('''
+          >>> r = conn.query_single('''
           ...     SELECT schema::Property {name, annotations: {name, @value}}
           ...     FILTER .name = 'listen_port'
           ...            AND .source.name = 'cfg::Config'
@@ -190,7 +190,7 @@ Tuples
 
         >>> import edgedb
         >>> conn = edgedb.connect()
-        >>> r = conn.query_one('''SELECT (1, 'a', [3])''')
+        >>> r = conn.query_single('''SELECT (1, 'a', [3])''')
         >>> r
         (1, 'a', [3])
         >>> len(r)
@@ -215,7 +215,7 @@ Named Tuples
 
         >>> import edgedb
         >>> conn = edgedb.connect()
-        >>> r = conn.query_one('''SELECT (a := 1, b := 'a', c := [3])''')
+        >>> r = conn.query_single('''SELECT (a := 1, b := 'a', c := [3])''')
         >>> r
         (a := 1, b := 'a', c := [3])
         >>> r.b
@@ -237,7 +237,7 @@ Arrays
 
         >>> import edgedb
         >>> conn = edgedb.connect()
-        >>> r = conn.query_one('''SELECT [1, 2, 3]''')
+        >>> r = conn.query_single('''SELECT [1, 2, 3]''')
         >>> r
         [1, 2, 3]
         >>> len(r)
@@ -258,7 +258,7 @@ RelativeDuration
 
         >>> import edgedb
         >>> conn = edgedb.connect()
-        >>> r = conn.query_one('''SELECT <cal::relative_duration>"1 year 2 days"''')
+        >>> r = conn.query_single('''SELECT <cal::relative_duration>"1 year 2 days"''')
         >>> r
         <edgedb.RelativeDuration "P1Y2D">
         >>> r.months

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -150,7 +150,7 @@ Below is an example of a connection pool usage:
         username = int(request.match_info.get('name'))
 
         # Execute the query on any pool connection
-        result = await pool.query_one_json(
+        result = await pool.query_single_json(
             '''
                 SELECT User {first_name, email, bio}
                 FILTER .name = <str>$username
@@ -181,7 +181,7 @@ You can also acquire connection from the pool:
 .. code-block:: python
 
     async with pool.acquire() as conn:
-        result = await conn.query_one_json(
+        result = await conn.query_single_json(
             '''
                 SELECT User {first_name, email, bio}
                 FILTER .name = <str>$username

--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -15,7 +15,7 @@ class ReadOnlyExecutor(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         ...
 
     @abc.abstractmethod
@@ -23,7 +23,7 @@ class ReadOnlyExecutor(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def query_one_json(self, query: str, *args, **kwargs) -> str:
+    def query_single_json(self, query: str, *args, **kwargs) -> str:
         ...
 
     # TODO(tailhook) add *args, **kwargs, when they are supported
@@ -44,7 +44,7 @@ class AsyncIOReadOnlyExecutor(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    async def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         ...
 
     @abc.abstractmethod
@@ -52,7 +52,7 @@ class AsyncIOReadOnlyExecutor(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def query_one_json(self, query: str, *args, **kwargs) -> str:
+    async def query_single_json(self, query: str, *args, **kwargs) -> str:
         ...
 
     # TODO(tailhook) add *args, **kwargs, when they are supported

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -346,7 +346,7 @@ class AsyncIOConnection(
         )
         return result
 
-    async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    async def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         inner = self._inner
         if inner._borrowed_for:
             raise base_con.borrow_error(inner._borrowed_for)
@@ -396,7 +396,7 @@ class AsyncIOConnection(
         )
         return result
 
-    async def query_one_json(self, query: str, *args, **kwargs) -> str:
+    async def query_single_json(self, query: str, *args, **kwargs) -> str:
         inner = self._inner
         if inner._borrowed_for:
             raise base_con.borrow_error(inner._borrowed_for)
@@ -486,12 +486,19 @@ class AsyncIOConnection(
             DeprecationWarning, 2)
         return await self.query(query, *args, **kwargs)
 
+    async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+        warnings.warn(
+            'The "query_one()" method is deprecated and is scheduled to be '
+            'removed. Use the "query_single()" method instead.',
+            DeprecationWarning, 2)
+        return await self.query_single(query, *args, **kwargs)
+
     async def fetchone(self, query: str, *args, **kwargs) -> typing.Any:
         warnings.warn(
             'The "fetchone()" method is deprecated and is scheduled to be '
-            'removed. Use the "query_one()" method instead.',
+            'removed. Use the "query_single()" method instead.',
             DeprecationWarning, 2)
-        return await self.query_one(query, *args, **kwargs)
+        return await self.query_single(query, *args, **kwargs)
 
     async def fetchall_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
@@ -500,12 +507,19 @@ class AsyncIOConnection(
             DeprecationWarning, 2)
         return await self.query_json(query, *args, **kwargs)
 
+    async def query_one_json(self, query: str, *args, **kwargs) -> str:
+        warnings.warn(
+            'The "query_one_json()" method is deprecated and is scheduled to '
+            'be removed. Use the "query_single_json()" method instead.',
+            DeprecationWarning, 2)
+        return await self.query_single_json(query, *args, **kwargs)
+
     async def fetchone_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
             'The "fetchone_json()" method is deprecated and is scheduled to '
-            'be removed. Use the "query_one_json()" method instead.',
+            'be removed. Use the "query_single_json()" method instead.',
             DeprecationWarning, 2)
-        return await self.query_one_json(query, *args, **kwargs)
+        return await self.query_single_json(query, *args, **kwargs)
 
 
 async def async_connect(dsn: str = None, *,

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -619,17 +619,17 @@ class AsyncIOPool(abstract.AsyncIOExecutor, options._OptionsMixin):
         async with self.acquire() as con:
             return await con.query(query, *args, **kwargs)
 
-    async def query_one(self, query, *args, **kwargs):
+    async def query_single(self, query, *args, **kwargs):
         async with self.acquire() as con:
-            return await con.query_one(query, *args, **kwargs)
+            return await con.query_single(query, *args, **kwargs)
 
     async def query_json(self, query, *args, **kwargs):
         async with self.acquire() as con:
             return await con.query_json(query, *args, **kwargs)
 
-    async def query_one_json(self, query, *args, **kwargs):
+    async def query_single_json(self, query, *args, **kwargs):
         async with self.acquire() as con:
-            return await con.query_one_json(query, *args, **kwargs)
+            return await con.query_single_json(query, *args, **kwargs)
 
     async def fetchall(self, query: str, *args, **kwargs) -> datatypes.Set:
         warnings.warn(
@@ -641,9 +641,9 @@ class AsyncIOPool(abstract.AsyncIOExecutor, options._OptionsMixin):
     async def fetchone(self, query: str, *args, **kwargs) -> typing.Any:
         warnings.warn(
             'The "fetchone()" method is deprecated and is scheduled to be '
-            'removed. Use the "query_one()" method instead.',
+            'removed. Use the "query_single()" method instead.',
             DeprecationWarning, 2)
-        return await self.query_one(query, *args, **kwargs)
+        return await self.query_single(query, *args, **kwargs)
 
     async def fetchall_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
@@ -655,9 +655,9 @@ class AsyncIOPool(abstract.AsyncIOExecutor, options._OptionsMixin):
     async def fetchone_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
             'The "fetchone_json()" method is deprecated and is scheduled to '
-            'be removed. Use the "query_one_json()" method instead.',
+            'be removed. Use the "query_single_json()" method instead.',
             DeprecationWarning, 2)
-        return await self.query_one_json(query, *args, **kwargs)
+        return await self.query_single_json(query, *args, **kwargs)
 
     async def execute(self, query):
         async with self.acquire() as con:

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -306,7 +306,7 @@ class BlockingIOConnection(
             io_format=protocol.IoFormat.BINARY,
         )
 
-    def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         inner = self._inner
         return self._get_protocol().sync_execute_anonymous(
             query=query,
@@ -341,7 +341,7 @@ class BlockingIOConnection(
             io_format=protocol.IoFormat.JSON_ELEMENTS,
         )
 
-    def query_one_json(self, query: str, *args, **kwargs) -> str:
+    def query_single_json(self, query: str, *args, **kwargs) -> str:
         inner = self._inner
         return self._get_protocol().sync_execute_anonymous(
             query=query,
@@ -360,12 +360,19 @@ class BlockingIOConnection(
             DeprecationWarning, 2)
         return self.query(query, *args, **kwargs)
 
+    def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+        warnings.warn(
+            'The "query_one()" method is deprecated and is scheduled to be '
+            'removed. Use the "query_single()" method instead.',
+            DeprecationWarning, 2)
+        return self.query_single(query, *args, **kwargs)
+
     def fetchone(self, query: str, *args, **kwargs) -> typing.Any:
         warnings.warn(
             'The "fetchone()" method is deprecated and is scheduled to be '
-            'removed. Use the "query_one()" method instead.',
+            'removed. Use the "query_single()" method instead.',
             DeprecationWarning, 2)
-        return self.query_one(query, *args, **kwargs)
+        return self.query_single(query, *args, **kwargs)
 
     def fetchall_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
@@ -374,12 +381,19 @@ class BlockingIOConnection(
             DeprecationWarning, 2)
         return self.query_json(query, *args, **kwargs)
 
+    def query_one_json(self, query: str, *args, **kwargs) -> str:
+        warnings.warn(
+            'The "query_one_json()" method is deprecated and is scheduled to '
+            'be removed. Use the "query_single_json()" method instead.',
+            DeprecationWarning, 2)
+        return self.query_single_json(query, *args, **kwargs)
+
     def fetchone_json(self, query: str, *args, **kwargs) -> str:
         warnings.warn(
             'The "fetchone_json()" method is deprecated and is scheduled to '
-            'be removed. Use the "query_one_json()" method instead.',
+            'be removed. Use the "query_single_json()" method instead.',
             DeprecationWarning, 2)
-        return self.query_one_json(query, *args, **kwargs)
+        return self.query_single_json(query, *args, **kwargs)
 
     def execute(self, query: str) -> None:
         self._get_protocol().sync_simple_query(query, enums.Capability.EXECUTE)

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -70,10 +70,10 @@ include "./codecs/codecs.pyx"
 cpython.datetime.import_datetime()
 
 
-_FETCHONE_METHOD = {
-    IoFormat.JSON: 'query_one_json',
+_QUERY_SINGLE_METHOD = {
+    IoFormat.JSON: 'query_single_json',
     IoFormat.JSON_ELEMENTS: '_fetchall_json_elements',
-    IoFormat.BINARY: 'query_one',
+    IoFormat.BINARY: 'query_single',
 }
 
 ALL_CAPABILITIES = 0xFFFFFFFFFFFFFFFF
@@ -325,7 +325,7 @@ cdef class SansIOProtocol:
             raise exc
 
         if expect_one and cardinality == CARDINALITY_NOT_APPLICABLE:
-            methname = _FETCHONE_METHOD[io_format]
+            methname = _QUERY_SINGLE_METHOD[io_format]
             raise errors.InterfaceError(
                 f'query cannot be executed with {methname}() as it '
                 f'does not return any data')
@@ -525,7 +525,7 @@ cdef class SansIOProtocol:
         if re_exec:
             assert new_cardinality is not None
             if expect_one and new_cardinality == CARDINALITY_NOT_APPLICABLE:
-                methname = _FETCHONE_METHOD[io_format]
+                methname = _QUERY_SINGLE_METHOD[io_format]
                 raise errors.InterfaceError(
                     f'query cannot be executed with {methname}() as it '
                     f'does not return any data')
@@ -644,7 +644,7 @@ cdef class SansIOProtocol:
             out_dc = <BaseCodec>codecs[2]
 
             if expect_one and has_na_cardinality:
-                methname = _FETCHONE_METHOD[io_format]
+                methname = _QUERY_SINGLE_METHOD[io_format]
                 raise errors.InterfaceError(
                     f'query cannot be executed with {methname}() as it '
                     f'does not return any data')
@@ -669,7 +669,7 @@ cdef class SansIOProtocol:
             if ret:
                 return ret[0], attrs
             else:
-                methname = _FETCHONE_METHOD[io_format]
+                methname = _QUERY_SINGLE_METHOD[io_format]
                 raise errors.NoDataError(
                     f'query executed via {methname}() returned no data')
         else:
@@ -1237,7 +1237,7 @@ cdef class SansIOProtocol:
 
     cdef _amend_parse_error(self, exc, IoFormat io_format, bint expect_one):
         if expect_one and exc.get_code() == result_cardinality_mismatch_code:
-            methname = _FETCHONE_METHOD[io_format]
+            methname = _QUERY_SINGLE_METHOD[io_format]
             new_exc = errors.InterfaceError(
                 f'query cannot be executed with {methname}() as it '
                 f'returns a multiset')

--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -206,7 +206,7 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
         )
         return result
 
-    async def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    async def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         con = self._connection_inner
         result, _ = await self._connection_impl._protocol.execute_anonymous(
             query=query,
@@ -231,7 +231,7 @@ class AsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
         )
         return result
 
-    async def query_one_json(self, query: str, *args, **kwargs) -> str:
+    async def query_single_json(self, query: str, *args, **kwargs) -> str:
         con = self._connection_inner
         result, _ = await self._connection_impl._protocol.execute_anonymous(
             query=query,
@@ -353,7 +353,7 @@ class Transaction(BaseTransaction, abstract.Executor):
             io_format=protocol.IoFormat.BINARY,
         )
 
-    def query_one(self, query: str, *args, **kwargs) -> typing.Any:
+    def query_single(self, query: str, *args, **kwargs) -> typing.Any:
         con = self._connection_inner
         return self._connection_impl._protocol.sync_execute_anonymous(
             query=query,
@@ -376,7 +376,7 @@ class Transaction(BaseTransaction, abstract.Executor):
             io_format=protocol.IoFormat.JSON,
         )
 
-    def query_one_json(self, query: str, *args, **kwargs) -> str:
+    def query_single_json(self, query: str, *args, **kwargs) -> str:
         con = self._connection_inner
         return self._connection_impl._protocol.sync_execute_anonymous(
             query=query,

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -84,7 +84,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                     ''')
                     1 / 0
         with self.assertRaises(edgedb.NoDataError):
-            await self.con.query_one('''
+            await self.con.query_single('''
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_02'
             ''')
@@ -125,7 +125,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                     await barrier.ready()
 
                     await lock.acquire()
-                    res = await tx.query_one('''
+                    res = await tx.query_single('''
                         SELECT (
                             INSERT test::Counter {
                                 name := <str>$name,

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -151,7 +151,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
-                await self.con.query_one("SELECT 1")
+                await self.con.query_single("SELECT 1")
 
         tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
@@ -163,7 +163,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
-                await self.con.query_one_json("SELECT 1")
+                await self.con.query_single_json("SELECT 1")
 
         tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -33,9 +33,9 @@ class TestEnum(tb.AsyncQueryTestCase):
     '''
 
     async def test_enum_01(self):
-        ct_red = await self.con.query_one('SELECT <CellType>"red"')
-        ct_white = await self.con.query_one('SELECT <CellType>"white"')
-        c_red = await self.con.query_one('SELECT <Color>"red"')
+        ct_red = await self.con.query_single('SELECT <CellType>"red"')
+        ct_white = await self.con.query_single('SELECT <CellType>"white"')
+        c_red = await self.con.query_single('SELECT <Color>"red"')
 
         self.assertTrue(isinstance(ct_red, edgedb.EnumValue))
         self.assertTrue(isinstance(ct_red.__tid__, uuid.UUID))

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -23,7 +23,7 @@ import edgedb
 from edgedb import _testbase as tb
 
 
-class TestSyncFetch(tb.SyncQueryTestCase):
+class TestSyncQuery(tb.SyncQueryTestCase):
 
     ISOLATED_METHODS = False
 
@@ -122,49 +122,49 @@ class TestSyncFetch(tb.SyncQueryTestCase):
             self.con.query('SELECT "HELLO"'),
             ["HELLO"])
 
-    def test_sync_fetch_single_command_01(self):
+    def test_sync_query_single_command_01(self):
         r = self.con.query('''
-            CREATE TYPE test::server_fetch_single_command_01 {
-                CREATE REQUIRED PROPERTY server_fetch_single_command_01 ->
+            CREATE TYPE test::server_query_single_command_01 {
+                CREATE REQUIRED PROPERTY server_query_single_command_01 ->
                     std::str;
             };
         ''')
         self.assertEqual(r, [])
 
         r = self.con.query('''
-            DROP TYPE test::server_fetch_single_command_01;
+            DROP TYPE test::server_query_single_command_01;
         ''')
         self.assertEqual(r, [])
 
         r = self.con.query('''
-            CREATE TYPE test::server_fetch_single_command_01 {
-                CREATE REQUIRED PROPERTY server_fetch_single_command_01 ->
+            CREATE TYPE test::server_query_single_command_01 {
+                CREATE REQUIRED PROPERTY server_query_single_command_01 ->
                     std::str;
             };
         ''')
         self.assertEqual(r, [])
 
         r = self.con.query('''
-            DROP TYPE test::server_fetch_single_command_01;
+            DROP TYPE test::server_query_single_command_01;
         ''')
         self.assertEqual(r, [])
 
         r = self.con.query_json('''
-            CREATE TYPE test::server_fetch_single_command_01 {
-                CREATE REQUIRED PROPERTY server_fetch_single_command_01 ->
+            CREATE TYPE test::server_query_single_command_01 {
+                CREATE REQUIRED PROPERTY server_query_single_command_01 ->
                     std::str;
             };
         ''')
         self.assertEqual(r, '[]')
 
         r = self.con.query_json('''
-            DROP TYPE test::server_fetch_single_command_01;
+            DROP TYPE test::server_query_single_command_01;
         ''')
         self.assertEqual(r, '[]')
 
         self.assertTrue(self.con._get_last_status().startswith('DROP'))
 
-    def test_sync_fetch_single_command_02(self):
+    def test_sync_query_single_command_02(self):
         r = self.con.query('''
             SET MODULE default;
         ''')
@@ -180,8 +180,10 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         ''')
         self.assertEqual(r, [])
 
-        with self.assertRaisesRegex(edgedb.InterfaceError, r'query_one\(\)'):
-            self.con.query_one('''
+        with self.assertRaisesRegex(
+                edgedb.InterfaceError,
+                r'query_single\(\)'):
+            self.con.query_single('''
                 SET ALIAS bar AS MODULE std;
             ''')
 
@@ -200,7 +202,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         ''')
         self.assertEqual(r, '[]')
 
-    def test_sync_fetch_single_command_03(self):
+    def test_sync_query_single_command_03(self):
         qs = [
             'START TRANSACTION',
             'DECLARE SAVEPOINT t0',
@@ -214,15 +216,15 @@ class TestSyncFetch(tb.SyncQueryTestCase):
         for _ in range(3):
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'cannot be executed with query_one\(\).*'
+                    r'cannot be executed with query_single\(\).*'
                     r'not return'):
-                self.con.query_one('START TRANSACTION')
+                self.con.query_single('START TRANSACTION')
 
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'cannot be executed with query_one_json\(\).*'
+                    r'cannot be executed with query_single_json\(\).*'
                     r'not return'):
-                self.con.query_one_json('START TRANSACTION')
+                self.con.query_single_json('START TRANSACTION')
 
         for _ in range(3):
             for q in qs:
@@ -235,17 +237,17 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InterfaceError,
-                r'cannot be executed with query_one\(\).*'
+                r'cannot be executed with query_single\(\).*'
                 r'not return'):
-            self.con.query_one('START TRANSACTION')
+            self.con.query_single('START TRANSACTION')
 
         with self.assertRaisesRegex(
                 edgedb.InterfaceError,
-                r'cannot be executed with query_one_json\(\).*'
+                r'cannot be executed with query_single_json\(\).*'
                 r'not return'):
-            self.con.query_one_json('START TRANSACTION')
+            self.con.query_single_json('START TRANSACTION')
 
-    def test_sync_fetch_single_command_04(self):
+    def test_sync_query_single_command_04(self):
         with self.assertRaisesRegex(edgedb.ProtocolError,
                                     'expected one statement'):
             self.con.query('''
@@ -255,7 +257,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
         with self.assertRaisesRegex(edgedb.ProtocolError,
                                     'expected one statement'):
-            self.con.query_one('''
+            self.con.query_single('''
                 SELECT 1;
                 SET MODULE blah;
             ''')
@@ -270,7 +272,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
     def test_sync_basic_datatypes_01(self):
         for _ in range(10):
             self.assertEqual(
-                self.con.query_one(
+                self.con.query_single(
                     'select ()'),
                 ())
 
@@ -280,7 +282,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
                 edgedb.Set([(1,)]))
 
             self.assertEqual(
-                self.con.query_one(
+                self.con.query_single(
                     'select <array<int64>>[]'),
                 [])
 
@@ -301,12 +303,12 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'query cannot be executed with query_one\('):
-                self.con.query_one('SELECT {1, 2}')
+                    r'query cannot be executed with query_single\('):
+                self.con.query_single('SELECT {1, 2}')
 
             with self.assertRaisesRegex(edgedb.NoDataError,
-                                        r'\bquery_one_json\('):
-                self.con.query_one_json('SELECT <int64>{}')
+                                        r'\bquery_single_json\('):
+                self.con.query_single_json('SELECT <int64>{}')
 
     def test_sync_basic_datatypes_02(self):
         self.assertEqual(
@@ -344,7 +346,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
 
             self.assertEqual(
                 json.loads(
-                    self.con.query_one_json(
+                    self.con.query_single_json(
                         'select ["a", "b"]')),
                 ["a", "b"])
 
@@ -369,7 +371,7 @@ class TestSyncFetch(tb.SyncQueryTestCase):
                 [])
 
             with self.assertRaises(edgedb.NoDataError):
-                self.con.query_one_json('SELECT <int64>{}')
+                self.con.query_single_json('SELECT <int64>{}')
 
     def test_sync_args_01(self):
         self.assertEqual(

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -81,7 +81,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                     ''')
                     1 / 0
         with self.assertRaises(edgedb.NoDataError):
-            self.con.query_one('''
+            self.con.query_single('''
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_02'
             ''')
@@ -125,7 +125,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                     barrier.ready()
 
                     lock.acquire()
-                    res = tx.query_one('''
+                    res = tx.query_single('''
                         SELECT (
                             INSERT test::Counter {
                                 name := <str>$name,

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -141,7 +141,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
-                self.con.query_one("SELECT 1")
+                self.con.query_single("SELECT 1")
 
         tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
@@ -153,7 +153,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
-                self.con.query_one_json("SELECT 1")
+                self.con.query_single_json("SELECT 1")
 
         tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,


### PR DESCRIPTION
Changes:
- added query_single()
- added query_single_json()
- deprecated query_one()
- deprecated query_one_json()
- renamed files, tests, and variables that used `fetch` in the name
  because it seems like we have effectivly renamed the fetch concept to
  query.