### PR TITLE
edgedb-python v0.17.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.16.0'
+__version__ = '0.17.0'


### PR DESCRIPTION
Fixes
=====

* Fix failing tests regarding --help (#207)
  (by @fantix in 956a2cac for #207)

* Fix confusing error when no arguments are passed to a query with named params (#208)
  (by @elprans in 8e0b334e for #208)

* Add Python 3.10 compatibility (#209)
  (by @elprans in 3472f17d for #209)

* Fix asyncio SSL unclosed warning (#210)
  (by @fantix in d718839c for #210)

* More reliable transport double-closing
  (by @fantix in 337b7794)

* Rename `query_one` to `query_single`
  (by @fmoor in f6900b01)