### PR TITLE
Fix retrying_transaction() on network errors

### DIFF
--- a/edgedb/protocol/asyncio_proto.pyx
+++ b/edgedb/protocol/asyncio_proto.pyx
@@ -49,7 +49,7 @@ cdef class AsyncIOProtocol(protocol.SansIOProtocol):
 
     cdef write(self, WriteBuffer buf):
         if self.transport is None:
-            raise ConnectionAbortedError
+            raise errors.ClientConnectionFailedTemporarilyError()
         self.transport.write(memoryview(buf))
 
     async def wait_for_message(self):

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -853,7 +853,7 @@ cdef class SansIOProtocol:
     def terminate(self):
         try:
             self.write(WriteBuffer.new_message(TERMINATE_MSG).end_message())
-        except ConnectionError:
+        except errors.ClientConnectionError:
             pass
 
     async def connect(self):


### PR DESCRIPTION
Errors from blocking socket operations are wrapped with EdgeDB errors.