### PR TITLE
Retry if start() raises a retryable error

### DIFF
--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -23,6 +23,9 @@ class AsyncIOIteration(_transaction.BaseAsyncIOTransaction):
             await self._start(single_connect=self.__iteration != 0)
 
     async def __aenter__(self):
+        if self._managed:
+            raise errors.InterfaceError(
+                'cannot enter context: already in an `async with` block')
         self._managed = True
         return self
 
@@ -133,6 +136,9 @@ class Iteration(_transaction.BaseBlockingIOTransaction):
             self._start(single_connect=self.__iteration != 0)
 
     def __enter__(self):
+        if self._managed:
+            raise errors.InterfaceError(
+                'cannot enter context: already in a `with` block')
         self._managed = True
         return self
 

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -5,23 +5,37 @@ from . import errors
 from . import transaction as _transaction
 
 
-class AsyncIOIteration(_transaction.AsyncIOTransaction):
+class AsyncIOIteration(_transaction.BaseAsyncIOTransaction):
     def __init__(self, retry, owner, iteration):
         super().__init__(owner, retry._options.transaction_options)
         self.__retry = retry
         self.__iteration = iteration
+        self.__started = False
 
-    async def start(self):
+    async def _ensure_transaction(self):
         if not self._managed:
             raise errors.InterfaceError(
                 "Only managed retriable transactions are supported. "
                 "Use `async with transaction:`"
             )
-        await self._start(single_connect=self.__iteration != 0)
+        if not self.__started:
+            self.__started = True
+            await self._start(single_connect=self.__iteration != 0)
+
+    async def __aenter__(self):
+        self._managed = True
+        return self
 
     async def __aexit__(self, extype, ex, tb):
+        self._managed = False
+        if not self.__started:
+            return False
+
         try:
-            await super().__aexit__(extype, ex, tb)
+            if extype is not None:
+                await self._rollback()
+            else:
+                await self._commit()
         except errors.EdgeDBError as err:
             if ex is None:
                 # On commit we don't know if commit is succeeded before the
@@ -101,23 +115,37 @@ class Retry(BaseRetry):
         return iteration
 
 
-class Iteration(_transaction.Transaction):
+class Iteration(_transaction.BaseBlockingIOTransaction):
     def __init__(self, retry, owner, iteration):
         super().__init__(owner, retry._options.transaction_options)
         self.__retry = retry
         self.__iteration = iteration
+        self.__started = False
 
-    def start(self):
+    def _ensure_transaction(self):
         if not self._managed:
             raise errors.InterfaceError(
                 "Only managed retriable transactions are supported. "
                 "Use `with transaction:`"
             )
-        self._start(single_connect=self.__iteration != 0)
+        if not self.__started:
+            self.__started = True
+            self._start(single_connect=self.__iteration != 0)
+
+    def __enter__(self):
+        self._managed = True
+        return self
 
     def __exit__(self, extype, ex, tb):
+        self._managed = False
+        if not self.__started:
+            return False
+
         try:
-            super().__exit__(extype, ex, tb)
+            if extype is not None:
+                self._rollback()
+            else:
+                self._commit()
         except errors.EdgeDBError as err:
             if ex is None:
                 # On commit we don't know if commit is succeeded before the

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -19,9 +19,11 @@
 import asyncio
 
 import logging
+import unittest.mock
 
 import edgedb
 from edgedb import compat
+from edgedb import errors
 from edgedb import RetryOptions
 from edgedb import _testbase as tb
 
@@ -88,6 +90,54 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_02'
             ''')
+
+    async def test_async_retry_begin(self):
+        patcher = unittest.mock.patch("edgedb.retry.AsyncIOIteration._start")
+        _start = patcher.start()
+
+        def cleanup():
+            try:
+                patcher.stop()
+            except RuntimeError:
+                pass
+
+        self.addCleanup(cleanup)
+
+        _start.side_effect = errors.BackendUnavailableError()
+
+        with self.assertRaises(errors.BackendUnavailableError):
+            async for tx in self.con.retrying_transaction():
+                async with tx:
+                    await tx.execute('''
+                        INSERT test::Counter {
+                            name := 'counter_retry_begin'
+                        };
+                    ''')
+        with self.assertRaises(edgedb.NoDataError):
+            await self.con.query_single('''
+                SELECT test::Counter
+                FILTER .name = 'counter_retry_begin'
+            ''')
+
+        async def recover_after_first_error(*_, **__):
+            patcher.stop()
+            raise errors.BackendUnavailableError()
+
+        _start.side_effect = recover_after_first_error
+        call_count = _start.call_count
+
+        async for tx in self.con.retrying_transaction():
+            async with tx:
+                await tx.execute('''
+                    INSERT test::Counter {
+                        name := 'counter_retry_begin'
+                    };
+                ''')
+        self.assertEqual(_start.call_count, call_count + 1)
+        await self.con.query_single('''
+            SELECT test::Counter
+            FILTER .name = 'counter_retry_begin'
+        ''')
 
     async def test_async_retry_conflict(self):
         await self.execute_conflict('counter2')
@@ -158,13 +208,30 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
         self.assertEqual(iterations, 3)
 
     async def test_async_transaction_interface_errors(self):
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'.*the transaction is already started'):
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'AsyncIOIteration' object has no attribute 'start'",
+        ):
             async for tx in self.con.retrying_transaction():
                 async with tx:
                     await tx.start()
 
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'AsyncIOIteration' object has no attribute 'rollback'",
+        ):
+            async for tx in self.con.retrying_transaction():
+                async with tx:
+                    await tx.rollback()
+
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'AsyncIOIteration' object has no attribute 'start'",
+        ):
+            async for tx in self.con.retrying_transaction():
+                await tx.start()
+
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*Use `async with transaction:`'):
             async for tx in self.con.retrying_transaction():
-                await tx.start()
+                await tx.execute("SELECT 123")

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -235,3 +235,12 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                                     r'.*Use `async with transaction:`'):
             async for tx in self.con.retrying_transaction():
                 await tx.execute("SELECT 123")
+
+        with self.assertRaisesRegex(
+            edgedb.InterfaceError,
+            r"already in an `async with` block",
+        ):
+            async for tx in self.con.retrying_transaction():
+                async with tx:
+                    async with tx:
+                        pass

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -18,10 +18,12 @@
 
 
 import threading
+import unittest.mock
 from concurrent import futures
 
 import edgedb
 from edgedb import _testbase as tb
+from edgedb import errors
 from edgedb import RetryOptions
 
 
@@ -70,7 +72,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                     };
                 ''')
 
-    def test_async_retry_02(self):
+    def test_sync_retry_02(self):
         with self.assertRaises(ZeroDivisionError):
             for tx in self.con.retrying_transaction():
                 with tx:
@@ -85,6 +87,54 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_02'
             ''')
+
+    def test_sync_retry_begin(self):
+        patcher = unittest.mock.patch("edgedb.retry.Iteration._start")
+        _start = patcher.start()
+
+        def cleanup():
+            try:
+                patcher.stop()
+            except RuntimeError:
+                pass
+
+        self.addCleanup(cleanup)
+
+        _start.side_effect = errors.BackendUnavailableError()
+
+        with self.assertRaises(errors.BackendUnavailableError):
+            for tx in self.con.retrying_transaction():
+                with tx:
+                    tx.execute('''
+                        INSERT test::Counter {
+                            name := 'counter_retry_begin'
+                        };
+                    ''')
+        with self.assertRaises(edgedb.NoDataError):
+            self.con.query_single('''
+                SELECT test::Counter
+                FILTER .name = 'counter_retry_begin'
+            ''')
+
+        def recover_after_first_error(*_, **__):
+            patcher.stop()
+            raise errors.BackendUnavailableError()
+
+        _start.side_effect = recover_after_first_error
+        call_count = _start.call_count
+
+        for tx in self.con.retrying_transaction():
+            with tx:
+                tx.execute('''
+                    INSERT test::Counter {
+                        name := 'counter_retry_begin'
+                    };
+                ''')
+        self.assertEqual(_start.call_count, call_count + 1)
+        self.con.query_single('''
+            SELECT test::Counter
+            FILTER .name = 'counter_retry_begin'
+        ''')
 
     def test_sync_retry_conflict(self):
         self.execute_conflict('counter2')
@@ -154,13 +204,30 @@ class TestSyncRetry(tb.SyncQueryTestCase):
         self.assertEqual(iterations, 3)
 
     def test_sync_transaction_interface_errors(self):
-        with self.assertRaisesRegex(edgedb.InterfaceError,
-                                    r'.*the transaction is already started'):
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'Iteration' object has no attribute 'start'",
+        ):
             for tx in self.con.retrying_transaction():
                 with tx:
                     tx.start()
 
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'Iteration' object has no attribute 'rollback'",
+        ):
+            for tx in self.con.retrying_transaction():
+                with tx:
+                    tx.rollback()
+
+        with self.assertRaisesRegex(
+            AttributeError,
+            "'Iteration' object has no attribute 'start'",
+        ):
+            for tx in self.con.retrying_transaction():
+                tx.start()
+
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*Use `with transaction:`'):
             for tx in self.con.retrying_transaction():
-                tx.start()
+                tx.execute("SELECT 123")

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -231,3 +231,12 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                                     r'.*Use `with transaction:`'):
             for tx in self.con.retrying_transaction():
                 tx.execute("SELECT 123")
+
+        with self.assertRaisesRegex(
+            edgedb.InterfaceError,
+            r"already in a `with` block",
+        ):
+            for tx in self.con.retrying_transaction():
+                with tx:
+                    with tx:
+                        pass


### PR DESCRIPTION
This issue was found in HA failover when the master Postgres is down, it raises a `BackendUnavailableError` to start a transaction, but the `retrying_transaction()` couldn't capture this retryable error from `start()`, because `start()` is called in `__enter__()` and the capture happens in `__exit__()`.

~This PR captures retryable errors in the `start()` of `retrying_transaction()`, marking the transaction with an error state which will cause the first query to raise the wrapped retryable error (or the state is checked in `__exit__()` too), so that the transaction can be properly retried.~

This PR solves the problem by making the `retrying_transaction()` start lazily when there is a `tx.execute()` or `tx.query*()` call, so that `__exit__()` wll be able to capture the retryable errors.