### PR TITLE
Fix broken pool connection cleanup

### DIFF
--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -146,8 +146,12 @@ class PoolConnectionHolder:
                 'a free connection holder')
 
         if self._con.is_closed():
-            # When closing, pool connections perform the necessary
-            # cleanup, so we don't have to do anything else here.
+            # This is usually the case when the connection is broken rather
+            # than closed by the user, so we need to call _release_on_close()
+            # here to release the holder back to the queue, because
+            # self._con._cleanup() was never called. On the other hand, it is
+            # safe to call self._release() twice - the second call is no-op.
+            self._release_on_close()
             return
 
         self._timeout = None

--- a/edgedb/protocol/asyncio_proto.pyx
+++ b/edgedb/protocol/asyncio_proto.pyx
@@ -19,6 +19,7 @@
 
 import asyncio
 
+from edgedb import errors
 from edgedb.pgproto.pgproto cimport (
     WriteBuffer,
     ReadBuffer,
@@ -109,7 +110,7 @@ cdef class AsyncIOProtocol(protocol.SansIOProtocol):
             self.disconnected_fut.set_exception(ConnectionResetError())
 
         if self.msg_waiter is not None and not self.msg_waiter.done():
-            self.msg_waiter.set_exception(ConnectionResetError())
+            self.msg_waiter.set_exception(errors.ClientConnectionClosedError())
             self.msg_waiter = None
 
         if self.transport is not None:


### PR DESCRIPTION
When a connection is broken (not actively closed by the user), that
connection holder in the pool is not cleaned, leading to issues like
creating zombie connections in the pool or pool.aclose() hangs forever.

To test retrying_transaction(), connection errors from
wait_for_message() is wrapped into a retryable EdgeDB client error type.
This is partially fixing the same issue in #222, but the latter should
aim for a more complete solution.