### PR TITLE
Bugfix: _borrowed_for is now set entering a transaction

### DIFF
--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -10,6 +10,8 @@ __all__ = ('Executor', 'AsyncIOExecutor')
 class ReadOnlyExecutor(abc.ABC):
     """Subclasses can execute *at least* read-only queries"""
 
+    __slots__ = ()
+
     @abc.abstractmethod
     def query(self, query: str, *args, **kwargs) -> datatypes.Set:
         ...
@@ -35,9 +37,13 @@ class ReadOnlyExecutor(abc.ABC):
 class Executor(ReadOnlyExecutor):
     """Subclasses can execute both read-only and modification queries"""
 
+    __slots__ = ()
+
 
 class AsyncIOReadOnlyExecutor(abc.ABC):
     """Subclasses can execute *at least* read-only queries"""
+
+    __slots__ = ()
 
     @abc.abstractmethod
     async def query(self, query: str, *args, **kwargs) -> datatypes.Set:
@@ -63,3 +69,5 @@ class AsyncIOReadOnlyExecutor(abc.ABC):
 
 class AsyncIOExecutor(AsyncIOReadOnlyExecutor):
     """Subclasses can execute both read-only and modification queries"""
+
+    __slots__ = ()

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -233,6 +233,8 @@ class AsyncIOConnection(
 
     async def ensure_connected(self, *, single_attempt=False):
         inner = self._inner
+        if inner._borrowed_for:
+            raise base_con.borrow_error(inner._borrowed_for)
         if not inner._impl or inner._impl.is_closed():
             await self._reconnect(single_attempt=single_attempt)
 

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -233,15 +233,12 @@ class AsyncIOConnection(
 
     async def ensure_connected(self, *, single_attempt=False):
         inner = self._inner
-        if inner._borrowed_for:
-            raise base_con.borrow_error(inner._borrowed_for)
         if not inner._impl or inner._impl.is_closed():
             await self._reconnect(single_attempt=single_attempt)
 
     # overriden by connection pool
     async def _reconnect(self, single_attempt=False):
         inner = self._inner
-        assert not inner._borrowed_for, inner._borrowed_for
         inner._impl = _AsyncIOConnectionImpl(
             inner._codecs_registry, inner._query_cache)
         await inner._impl.connect(inner._loop, inner._addrs,
@@ -261,7 +258,7 @@ class AsyncIOConnection(
     ) -> datatypes.Set:
         inner = self._inner
         if inner._borrowed_for:
-            raise base_con.borrow_error(self._inner._borrowed_for)
+            raise base_con.borrow_error(inner._borrowed_for)
         if not inner._impl or inner._impl.is_closed():
             await self._reconnect()
         result, _ = await inner._impl._protocol.execute_anonymous(

--- a/edgedb/base_con.py
+++ b/edgedb/base_con.py
@@ -83,6 +83,7 @@ class _InnerConnection:
 
 
 class BaseConnection:
+    _inner: _InnerConnection
 
     def connected_addr(self):
         return self._inner._impl._addr

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -209,14 +209,11 @@ class BlockingIOConnection(
 
     def ensure_connected(self, single_attempt=False):
         inner = self._inner
-        if inner._borrowed_for:
-            raise base_con.borrow_error(inner._borrowed_for)
         if not inner._impl or inner._impl.is_closed():
             self._reconnect(single_attempt=single_attempt)
 
     def _reconnect(self, single_attempt=False):
         inner = self._inner
-        assert not inner._borrowed_for, inner._borrowed_for
         inner._impl = _BlockingIOConnectionImpl(
             inner._codecs_registry, inner._query_cache)
         inner._impl.connect(inner._addrs, inner._config, inner._params,

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -209,6 +209,8 @@ class BlockingIOConnection(
 
     def ensure_connected(self, single_attempt=False):
         inner = self._inner
+        if inner._borrowed_for:
+            raise base_con.borrow_error(inner._borrowed_for)
         if not inner._impl or inner._impl.is_closed():
             self._reconnect(single_attempt=single_attempt)
 

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -21,17 +21,23 @@ class AsyncIOIteration(_transaction.BaseAsyncIOTransaction):
         if not self.__started:
             self.__started = True
             await self._start(single_connect=self.__iteration != 0)
+            if self._pool is not None:
+                self._borrow()
 
     async def __aenter__(self):
         if self._managed:
             raise errors.InterfaceError(
                 'cannot enter context: already in an `async with` block')
         self._managed = True
+        if self._pool is None:
+            self._borrow()
         return self
 
     async def __aexit__(self, extype, ex, tb):
         self._managed = False
         if not self.__started:
+            if self._connection is not None:
+                self._maybe_return()
             return False
 
         try:
@@ -140,11 +146,13 @@ class Iteration(_transaction.BaseBlockingIOTransaction):
             raise errors.InterfaceError(
                 'cannot enter context: already in a `with` block')
         self._managed = True
+        self._borrow()
         return self
 
     def __exit__(self, extype, ex, tb):
         self._managed = False
         if not self.__started:
+            self._maybe_return()
             return False
 
         try:

--- a/edgedb/retry.py
+++ b/edgedb/retry.py
@@ -22,6 +22,9 @@ class AsyncIOIteration(_transaction.BaseAsyncIOTransaction):
             self.__started = True
             await self._start(single_connect=self.__iteration != 0)
             if self._pool is not None:
+                # Having a pool means we just acquired the connection in
+                # _start() - let's mark it as borrowed for transaction anyways
+                # just in case the connection is somehow accessed separately.
                 self._borrow()
 
     async def __aenter__(self):
@@ -30,14 +33,19 @@ class AsyncIOIteration(_transaction.BaseAsyncIOTransaction):
                 'cannot enter context: already in an `async with` block')
         self._managed = True
         if self._pool is None:
+            # Borrow the connection for transaction now if it's not on a pool,
+            # because that means we already have the connection now, and
+            # further use of the connection like this should be prevented:
+            #     async for tx in conn.retrying_transaction():
+            #         async with tx:
+            #             await conn.query("...")  # <- wrong use after borrow
             self._borrow()
         return self
 
     async def __aexit__(self, extype, ex, tb):
         self._managed = False
         if not self.__started:
-            if self._connection is not None:
-                self._maybe_return()
+            self._maybe_return()
             return False
 
         try:

--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -96,6 +96,16 @@ class BaseTransaction:
         self.__check_state('rollback')
         return 'ROLLBACK;'
 
+    def _borrow(self):
+        inner = self._connection._inner
+        if inner._borrowed_for:
+            raise base_con.borrow_error(inner._borrowed_for)
+        inner._borrowed_for = base_con.BorrowReason.TRANSACTION
+
+    def _maybe_return(self):
+        if self._connection is not None:
+            self._connection._inner._borrowed_for = None
+
     def __repr__(self):
         attrs = []
         attrs.append('state:{}'.format(self._state.name.lower()))
@@ -117,48 +127,44 @@ class BaseAsyncIOTransaction(BaseTransaction, abstract.AsyncIOExecutor):
         query = self._make_start_query()
         if self._pool is not None:
             self._connection = await self._pool._acquire()
-        if self._connection._inner._borrowed_for:
-            raise base_con.borrow_error(self._connection._inner._borrowed_for)
         await self._connection.ensure_connected(single_attempt=single_connect)
         self._connection_inner = self._connection._inner
         self._connection_impl = self._connection._inner._impl
-        self._connection_inner._borrowed_for = (
-            base_con.BorrowReason.TRANSACTION
-        )
         try:
             await self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
-            self._connection_inner._borrowed_for = None
             raise
         else:
             self._state = TransactionState.STARTED
 
     async def _commit(self):
-        query = self._make_commit_query()
         try:
-            await self._connection_impl.privileged_execute(query)
-        except BaseException:
-            self._state = TransactionState.FAILED
-            raise
-        else:
-            self._state = TransactionState.COMMITTED
+            query = self._make_commit_query()
+            try:
+                await self._connection_impl.privileged_execute(query)
+            except BaseException:
+                self._state = TransactionState.FAILED
+                raise
+            else:
+                self._state = TransactionState.COMMITTED
         finally:
-            self._connection_inner._borrowed_for = None
+            self._maybe_return()
             if self._pool is not None:
                 await self._pool._release(self._connection)
 
     async def _rollback(self):
-        query = self._make_rollback_query()
         try:
-            await self._connection_impl.privileged_execute(query)
-        except BaseException:
-            self._state = TransactionState.FAILED
-            raise
-        else:
-            self._state = TransactionState.ROLLEDBACK
+            query = self._make_rollback_query()
+            try:
+                await self._connection_impl.privileged_execute(query)
+            except BaseException:
+                self._state = TransactionState.FAILED
+                raise
+            else:
+                self._state = TransactionState.ROLLEDBACK
         finally:
-            self._connection_inner._borrowed_for = None
+            self._maybe_return()
             if self._pool is not None:
                 await self._pool._release(self._connection)
 
@@ -259,6 +265,7 @@ class AsyncIOTransaction(BaseAsyncIOTransaction):
     async def start(self) -> None:
         """Enter the transaction or savepoint block."""
         await self._start()
+        self._borrow()
 
     async def commit(self) -> None:
         """Exit the transaction or savepoint block and commit changes."""
@@ -281,46 +288,42 @@ class BaseBlockingIOTransaction(BaseTransaction, abstract.Executor):
     def _start(self, single_connect=False) -> None:
         query = self._make_start_query()
         # no pools supported for blocking con
-        if self._connection._inner._borrowed_for:
-            raise base_con.borrow_error(self._connection._inner._borrowed_for)
         self._connection.ensure_connected(single_attempt=single_connect)
         self._connection_inner = self._connection._inner
-        self._connection_inner._borrowed_for = (
-            base_con.BorrowReason.TRANSACTION
-        )
         self._connection_impl = self._connection_inner._impl
         try:
             self._connection_impl.privileged_execute(query)
         except BaseException:
             self._state = TransactionState.FAILED
-            self._connection_inner._borrowed_for = None
             raise
         else:
             self._state = TransactionState.STARTED
 
     def _commit(self):
-        query = self._make_commit_query()
         try:
-            self._connection_impl.privileged_execute(query)
-        except BaseException:
-            self._state = TransactionState.FAILED
-            raise
-        else:
-            self._state = TransactionState.COMMITTED
+            query = self._make_commit_query()
+            try:
+                self._connection_impl.privileged_execute(query)
+            except BaseException:
+                self._state = TransactionState.FAILED
+                raise
+            else:
+                self._state = TransactionState.COMMITTED
         finally:
-            self._connection_inner._borrowed_for = None
+            self._maybe_return()
 
     def _rollback(self):
-        query = self._make_rollback_query()
         try:
-            self._connection_impl.privileged_execute(query)
-        except BaseException:
-            self._state = TransactionState.FAILED
-            raise
-        else:
-            self._state = TransactionState.ROLLEDBACK
+            query = self._make_rollback_query()
+            try:
+                self._connection_impl.privileged_execute(query)
+            except BaseException:
+                self._state = TransactionState.FAILED
+                raise
+            else:
+                self._state = TransactionState.ROLLEDBACK
         finally:
-            self._connection_inner._borrowed_for = None
+            self._maybe_return()
 
     def _ensure_transaction(self):
         pass
@@ -402,6 +405,7 @@ class Transaction(BaseBlockingIOTransaction):
     def start(self) -> None:
         """Enter the transaction or savepoint block."""
         self._start()
+        self._borrow()
 
     def commit(self) -> None:
         """Exit the transaction or savepoint block and commit changes."""

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -246,3 +246,8 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                 async with tx:
                     async with tx:
                         pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError, r".*is borrowed.*"):
+            async for tx in self.con.retrying_transaction():
+                async with tx:
+                    await self.con.execute("SELECT 123")

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -170,3 +170,9 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
                                     r'.*is borrowed.*'):
             async with tr:
                 await self.con.execute("SELECT 1")
+
+        tr = self.con.raw_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            async with tr:
+                await self.con.ensure_connected()

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -242,3 +242,8 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                 with tx:
                     with tx:
                         pass
+
+        with self.assertRaisesRegex(edgedb.InterfaceError, r".*is borrowed.*"):
+            for tx in self.con.retrying_transaction():
+                with tx:
+                    self.con.execute("SELECT 123")

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -167,3 +167,9 @@ class TestSyncTx(tb.SyncQueryTestCase):
                                     r'.*is borrowed.*'):
             with tr:
                 self.con.execute("SELECT 1")
+
+        tr = self.con.raw_transaction()
+        with self.assertRaisesRegex(edgedb.InterfaceError,
+                                    r'.*is borrowed.*'):
+            with tr:
+                self.con.ensure_connected()


### PR DESCRIPTION
Bug was introduced in #228 - this is not supposed to work:

```python
async for tx in con.retrying_transaction():
    async with tx:
        con.query("SELECT 123")  # <- con, not tx. Should raise an error here
```

This is fixed in a way that `_borrowed_for` is set in `__aenter__`.