### PR TITLE
Fix `credentials_file` argument typo on `async_connect`

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -546,7 +546,7 @@ class AsyncIOConnection(
 
 
 async def async_connect(dsn: str = None, *,
-                        credentils_file: str = None,
+                        credentials_file: str = None,
                         host: str = None, port: int = None,
                         user: str = None, password: str = None,
                         database: str = None,
@@ -562,7 +562,7 @@ async def async_connect(dsn: str = None, *,
         connection_class = AsyncIOConnection
 
     connect_config, client_config = con_utils.parse_connect_arguments(
-        dsn=dsn, credentials_file=credentils_file, host=host, port=port,
+        dsn=dsn, credentials_file=credentials_file, host=host, port=port,
         user=user, password=password, database=database, timeout=timeout,
         tls_ca_file=tls_ca_file, tls_security=tls_security,
         wait_until_available=wait_until_available,


### PR DESCRIPTION
Fixing a small typo on `async_connect` method.
As this argument was recently introduced in https://github.com/edgedb/edgedb-python/pull/241 and is not in the latest released version (`0.17.3`), it should not be a breaking change.