### PR TITLE
Rename create_client() -> create_async_client()

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -21,6 +21,36 @@ Connection
 
     Establish a connection to an EdgeDB server.
 
+    Deprecated. Use ``create_async_client()`` instead.
+
+    Example:
+
+    .. code-block:: pycon
+
+        >>> import asyncio
+        >>> import edgedb
+        >>> async def main():
+        ...     con = await edgedb.async_connect(user='edgedb')
+        ...     print(await con.query_single('SELECT 1 + 1'))
+        ...
+        >>> asyncio.run(main())
+        {2}
+
+.. _edgedb-python-asyncio-api-pool:
+
+Client Connection Pool
+======================
+
+.. py:function:: create_async_client(dsn=None, *, \
+            host=None, port=None, \
+            admin=None, \
+            user=None, password=None, \
+            database=None, \
+            timeout=60, \
+            concurrency=None)
+
+    Create an asynchronous lazy connection pool.
+
     The connection parameters may be specified either as a connection
     URI in *dsn*, or as specific keyword arguments, or both.
     If both *dsn* and keyword arguments are specified, the latter
@@ -66,7 +96,7 @@ Connection
         addresses.
 
         If not specified, the value parsed from the *dsn* argument is used,
-        or the value of the ``EDGEB_PORT`` environment variable, or ``5656``
+        or the value of the ``EDGEDB_PORT`` environment variable, or ``5656``
         if neither is specified.
 
     :param admin:
@@ -97,310 +127,9 @@ Connection
     :param float timeout:
         Connection timeout in seconds.
 
-    :return: A :py:class:`AsyncIOConnection` instance.
-
-    Example:
-
-    .. code-block:: pycon
-
-        >>> import asyncio
-        >>> import edgedb
-        >>> async def main():
-        ...     con = await edgedb.async_connect(user='edgedb')
-        ...     print(await con.query_single('SELECT 1 + 1'))
-        ...
-        >>> asyncio.run(main())
-        {2}
-
-
-.. py:class:: AsyncIOConnection
-
-    A representation of a database session.
-
-    Connections are created by calling :py:func:`~edgedb.async_connect`.
-
-
-    .. py:coroutinemethod:: query(query, *args, **kwargs)
-
-        Run a query and return the results as a
-        :py:class:`edgedb.Set <edgedb.Set>` instance.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            An instance of :py:class:`edgedb.Set <edgedb.Set>` containing
-            the query result.
-
-        Note that positional and named query arguments cannot be mixed.
-
-
-    .. py:coroutinemethod:: query_single(query, *args, **kwargs)
-
-        Run an optional singleton-returning query and return its element.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            Query result.
-
-        The *query* must return no more than one element.  If the query returns
-        more than one element, an ``edgedb.ResultCardinalityMismatchError``
-        is raised, if it returns an empty set, ``None`` is returned.
-
-        Note, that positional and named query arguments cannot be mixed.
-
-
-    .. py:coroutinemethod:: query_required_single(query, *args, **kwargs)
-
-        Run a singleton-returning query and return its element.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            Query result.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element, an ``edgedb.ResultCardinalityMismatchError``
-        is raised, if it returns an empty set, an ``edgedb.NoDataError``
-        is raised.
-
-        Note, that positional and named query arguments cannot be mixed.
-
-
-    .. py:coroutinemethod:: query_json(query, *args, **kwargs)
-
-        Run a query and return the results as JSON.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            A JSON string containing an array of query results.
-
-        Note, that positional and named query arguments cannot be mixed.
-
-        .. note::
-
-            Caution is advised when reading ``decimal`` values using
-            this method. The JSON specification does not have a limit
-            on significant digits, so a ``decimal`` number can be
-            losslessly represented in JSON. However, the default JSON
-            decoder in Python will read all such numbers as ``float``
-            values, which may result in errors or precision loss. If
-            such loss is unacceptable, then consider casting the value
-            into ``str`` and decoding it on the client side into a
-            more appropriate type, such as ``Decimal``.
-
-
-    .. py:coroutinemethod:: query_single_json(query, *args, **kwargs)
-
-        Run an optional singleton-returning query and return its element
-        in JSON.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            Query result encoded in JSON.
-
-        The *query* must return no more than one element.  If the query returns
-        more than one element, an ``edgedb.ResultCardinalityMismatchError``
-        is raised, if it returns an empty set, ``"null"`` is returned.
-
-        Note, that positional and named query arguments cannot be mixed.
-
-        .. note::
-
-            Caution is advised when reading ``decimal`` values using
-            this method. The JSON specification does not have a limit
-            on significant digits, so a ``decimal`` number can be
-            losslessly represented in JSON. However, the default JSON
-            decoder in Python will read all such numbers as ``float``
-            values, which may result in errors or precision loss. If
-            such loss is unacceptable, then consider casting the value
-            into ``str`` and decoding it on the client side into a
-            more appropriate type, such as ``Decimal``.
-
-
-    .. py:coroutinemethod:: query_required_single_json(query, *args, **kwargs)
-
-        Run a singleton-returning query and return its element in JSON.
-
-        :param str query: Query text.
-        :param args: Positional query arguments.
-        :param kwargs: Named query arguments.
-
-        :return:
-            Query result encoded in JSON.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element, an ``edgedb.ResultCardinalityMismatchError``
-        is raised, if it returns an empty set, an ``edgedb.NoDataError``
-        is raised.
-
-        Note, that positional and named query arguments cannot be mixed.
-
-        .. note::
-
-            Caution is advised when reading ``decimal`` values using
-            this method. The JSON specification does not have a limit
-            on significant digits, so a ``decimal`` number can be
-            losslessly represented in JSON. However, the default JSON
-            decoder in Python will read all such numbers as ``float``
-            values, which may result in errors or precision loss. If
-            such loss is unacceptable, then consider casting the value
-            into ``str`` and decoding it on the client side into a
-            more appropriate type, such as ``Decimal``.
-
-
-    .. py:coroutinemethod:: execute(query)
-
-        Execute an EdgeQL command (or commands).
-
-        :param str query: Query text.
-
-        The commands must take no arguments.
-
-        Example:
-
-        .. code-block:: pycon
-
-            >>> await con.execute('''
-            ...     CREATE TYPE MyType {
-            ...         CREATE PROPERTY a -> int64
-            ...     };
-            ...     FOR x IN {100, 200, 300}
-            ...     UNION INSERT MyType { a := x };
-            ... ''')
-
-        .. note::
-            If the results of *query* are desired, :py:meth:`query`,
-            :py:meth:`query_single` or :py:meth:`query_required_single`
-            should be used instead.
-
-    .. py:method:: transaction()
-
-        Start a transaction with auto-retry semantics.
-
-        This is the preferred method of initiating and running a database
-        transaction in a robust fashion.  The ``transaction()``
-        transaction loop will attempt to re-execute the transaction loop
-        body if a transient error occurs, such as a network error or a
-        transaction serialization error.
-
-        Returns an instance of :py:class:`AsyncIORetry`.
-
-        See :ref:`edgedb-python-asyncio-api-transaction` for more details.
-
-        Example:
-
-        .. code-block:: python
-
-            async for tx in con.transaction():
-                async with tx:
-                    value = await tx.query_single("SELECT Counter.value")
-                    await tx.execute(
-                        "UPDATE Counter SET { value := <int64>$value }",
-                        value=value + 1,
-                    )
-
-        Note that we are executing queries on the ``tx`` object rather
-        than on the original connection.
-
-    .. py:method:: raw_transaction()
-
-        **Deprecated**. Use :py:meth:`transaction` along with
-        ``with_retry_options(RetryOptions(attempts=1))`` instead.
-
-        Start a low-level transaction.
-
-        Unlike ``transaction()``, ``raw_transaction()``
-        will not attempt to re-run the nested code block in case a retryable
-        error happens.
-
-        This is a low-level API and it is advised to use the
-        ``transaction()`` method instead.
-
-        A call to ``raw_transaction()`` returns
-        :py:class:`AsyncIOTransaction`.
-
-        Example:
-
-        .. code-block:: python
-
-            async with con.raw_transaction() as tx:
-                value = await tx.query_single("SELECT Counter.value")
-                await tx.execute(
-                    "UPDATE Counter SET { value := <int64>$value }",
-                    value=value + 1,
-                )
-
-        Note that we are executing queries on the ``tx`` object,
-        rather than on the original connection ``con``.
-
-
-    .. py:coroutinemethod:: aclose()
-
-        Close the connection gracefully.
-
-
-    .. py:method:: is_closed()
-
-        Return ``True`` if the connection is closed.
-
-
-.. _edgedb-python-asyncio-api-pool:
-
-Client Connection Pool
-======================
-
-.. py:function:: create_client
-
-    Create an asynchronous lazy connection pool.
-
-    :param str dsn:
-        Connection arguments specified using as a single string in
-        the following format:
-        ``edgedb://user:pass@host:port/database?option=value``.
-
-    :param \*\*connect_kwargs:
-        Keyword arguments for the :py:func:`~edgedb.async_connect`
-        function.
-
-    :param AsyncIOConnection connection_class:
-        The class to use for connections.  Must be a subclass of
-        :py:class:`AsyncIOConnection`.
-
     :param int concurrency:
         Max number of connections in the pool. If not set, the suggested
         concurrency value provided by the server is used.
-
-    :param on_acquire:
-        **Deprecated**. Use the query methods on
-        :py:class:`Client <edgedb.AsyncIOClient>` instead of
-        acquiring a connection.
-
-        A coroutine to prepare a connection right before it is returned
-        from :py:meth:`Client.acquire() <edgedb.AsyncIOClient.acquire>`.
-
-    :param on_release:
-        **Deprecated**. Use the query methods on
-        :py:class:`Client <edgedb.AsyncIOClient>` instead of
-        acquiring a connection.
-
-        A coroutine called when a connection is about to be released
-        to the pool.
-
-    :param on_connect:
-        A coroutine to initialize a connection when it is created.
 
     :return: An instance of :py:class:`AsyncIOClient`.
 
@@ -419,17 +148,17 @@ Client Connection Pool
 
     .. code-block:: python
 
-        async with edgedb.create_client(user='edgedb') as client:
-            await client.query('SELECT {1, 2, 3}')
+        client = edgedb.create_async_client(user='edgedb')
+        await client.query('SELECT {1, 2, 3}')
 
     Transactions can be executed as well:
 
     .. code-block:: python
 
-        async with edgedb.create_client(user='edgedb') as client:
-            async for tx in client.transaction():
-                async with tx:
-                    await tx.query('SELECT {1, 2, 3}')
+        client = edgedb.create_async_client(user='edgedb')
+        async for tx in client.transaction():
+            async with tx:
+                await tx.query('SELECT {1, 2, 3}')
 
 
 .. py:class:: AsyncIOClient()
@@ -441,90 +170,6 @@ Client Connection Pool
 
     Pools are created by calling
     :py:func:`~edgedb.create_client`.
-
-    .. py:coroutinemethod:: acquire()
-
-        **Deprecated**. Use the query methods on
-        :py:class:`Client <edgedb.AsyncIOClient>` instead of
-        acquiring a connection.
-
-        Acquire a database connection from the pool.
-
-        :return: An instance of :py:class:`AsyncIOConnection`.
-
-        Can be used in an ``await`` expression or with an ``async with`` block.
-
-        .. code-block:: python
-
-            async with client.acquire() as con:
-                await con.execute(...)
-
-        Or:
-
-        .. code-block:: python
-
-            con = await client.acquire()
-            try:
-                await con.execute(...)
-            finally:
-                await client.release(con)
-
-    .. py:coroutinemethod:: release(connection)
-
-        **Deprecated**. Use the query methods on
-        :py:class:`Client <edgedb.AsyncIOClient>` instead of
-        acquiring a connection.
-
-        Release a database connection back to the pool.
-
-        :param AsyncIOConnection connection:
-            A :py:class:`AsyncIOConnection` object
-            to release.
-
-    .. py:coroutinemethod:: aclose()
-
-        Attempt to gracefully close all connections in the pool.
-
-        Wait until all pool connections are released, close them and
-        shut down the pool.  If any error (including cancellation) occurs
-        in ``close()`` the pool will terminate by calling
-        :py:meth:`Client.terminate() <edgedb.AsyncIOClient.terminate>`.
-
-        It is advisable to use :py:func:`python:asyncio.wait_for` to set
-        a timeout.
-
-    .. py:method:: terminate()
-
-        Terminate all connections in the pool.
-
-    .. py:coroutinemethod:: expire_connections()
-
-        Expire all currently open connections.
-
-        Cause all currently open connections to get replaced on the
-        next :py:meth:`~edgedb.AsyncIOClient.acquire()` call.
-
-    .. py:method:: set_connect_args(dsn=None, **connect_kwargs)
-
-        Set the new connection arguments for this pool.
-
-        :param str dsn:
-            If this parameter does not start with ``edgedb://`` then this is
-            a :ref:`name of an instance
-            <ref_reference_connection_instance_name>`.
-
-            Otherwise it specifies a single string in the following format:
-            ``edgedb://user:pass@host:port/database?option=value``.
-
-        :param \*\*connect_kwargs:
-            Keyword arguments for the :py:func:`~async_connect`
-            function.
-
-        The new connection arguments will be used for all subsequent
-        new connection attempts.  Existing connections will remain until
-        they expire. Use :py:meth:`Client.expire_connections()
-        <edgedb.AsyncIOClient.expire_connections>` to expedite
-        the connection expiry.
 
     .. py:coroutinemethod:: ensure_connected()
 
@@ -630,35 +275,21 @@ Client Connection Pool
         Note that we are executing queries on the ``tx`` object rather
         than on the original client.
 
-    .. py:method:: raw_transaction()
+    .. py:coroutinemethod:: aclose()
 
-        **Deprecated**. Use :py:meth:`transaction` along with
-        ``with_retry_options(RetryOptions(attempts=1))`` instead.
+        Attempt to gracefully close all connections in the pool.
 
-        Execute a non-retryable transaction.
+        Wait until all pool connections are released, close them and
+        shut down the pool.  If any error (including cancellation) occurs
+        in ``close()`` the pool will terminate by calling
+        :py:meth:`Client.terminate() <edgedb.AsyncIOClient.terminate>`.
 
-        Contrary to ``transaction()``, ``raw_transaction()``
-        will not attempt to re-run the nested code block in case a retryable
-        error happens.
+        It is advisable to use :py:func:`python:asyncio.wait_for` to set
+        a timeout.
 
-        This is a low-level API and it is advised to use the
-        ``transaction()`` method instead.
+    .. py:method:: terminate()
 
-        A call to ``raw_transaction()`` returns :py:class:`AsyncIOTransaction`.
-
-        Example:
-
-        .. code-block:: python
-
-            async with client.raw_transaction() as tx:
-                value = await tx.query_single("SELECT Counter.value")
-                await tx.execute(
-                    "UPDATE Counter SET { value := <int64>$value",
-                    value=value,
-                )
-
-        Note executing queries on ``tx`` object rather than the original
-        client.
+        Terminate all connections in the pool.
 
 
 .. _edgedb-python-asyncio-api-transaction:
@@ -740,25 +371,6 @@ See also:
 
     Instances of this type are created by calling the
     :py:meth:`AsyncIOConnection.raw_transaction()` method.
-
-
-    .. py:coroutinemethod:: start()
-
-        Start a transaction or create a savepoint.
-
-    .. py:coroutinemethod:: commit()
-
-        Exit the transaction or savepoint block and commit changes.
-
-    .. py:coroutinemethod:: rollback()
-
-        Exit the transaction or savepoint block and discard changes.
-
-    .. describe:: async with c:
-
-        Start and commit/rollback the transaction or savepoint block
-        automatically when entering and exiting the code inside the
-        context manager block.
 
     .. py:coroutinemethod:: query(query, *args, **kwargs)
 

--- a/edgedb/__init__.py
+++ b/edgedb/__init__.py
@@ -21,17 +21,21 @@
 
 from ._version import __version__
 
-from edgedb.datatypes.datatypes import Tuple, NamedTuple, EnumValue, RelativeDuration, ConfigMemory
+from edgedb.datatypes.datatypes import (
+    Tuple, NamedTuple, EnumValue, RelativeDuration, ConfigMemory
+)
 from edgedb.datatypes.datatypes import Set, Object, Array, Link, LinkSet
 
 from .abstract import Executor, AsyncIOExecutor
+
 from .asyncio_con import async_connect_raw, AsyncIOConnection
 from .asyncio_pool import (
-    create_client,
+    create_async_client,
     create_async_pool,
     async_connect,
     AsyncIOClient
 )
+
 from .blocking_con import connect, BlockingIOConnection
 from .options import RetryCondition, IsolationLevel, default_backoff
 from .options import RetryOptions, TransactionOptions


### PR DESCRIPTION
While there ensure that the new client API doesn't inherit old
deprecated methods (like 'acquire()') and connection parameters
(like 'on_acquire()').

Fix the docs to only mention the actual (non-depreacted) APIs.