### PR TITLE
edgedb-python v0.18.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.18.0a2'
+__version__ = '0.18.0'


### PR DESCRIPTION
Changes
=======

* support protocol version 0.12
  (by @fmoor in 5ce52ed8)

* Update to protocol version 0.13
  (by @1st1 in c690250, 8by @fmoor in 5ce52ed8, by @jaclarke in a5a6218d for #253)

* Lookup `edgedb.toml` recursively in parent directories
  (by @fmoor in d9a12b88 for #245)

* Update connection parameter resolution
  (by @jaclarke in 085f5748 for #241)

* Implement `EDGEDB_CLIENT_SECURITY`
  (by @fmoor in ac46c374)

* Add optional/required `query_single*` methods + rename `retrying_transaction` + update pool to `create_client` API
  (by @jaclarke in f2ae0d0e for #249)

Deprecations
============

* Deprecate `Pool.acquire()` and `Pool.release()`
  (by @fmoor in 2d501e97 for #217)

* Rename `tls_verify_hostname` to `tls_security`
  (by @fmoor in 2086b866)

Fixes
=====

* Do not attempt to del transport in `connection_lost` if it has been already
  (by @elprans in c719e79b for #215)

* Retry if `start()` raises a retryable error (#228)
  (by @fantix in ffaae01a for #228)

* Fix broken pool connection cleanup
  (by @fantix in be449591 for #222)

* Fix deprecated usage of `SSLContext` (#231)
  (by @elprans in f73f9999 for #231)

* Bugfix: `_borrowed_for` is now set entering a transaction (#233)
  (by @fantix in bf763d1d for #233)

* Send zero arguments as zero-length bytes in proto 0.12 (#238)
  (by @tailhook in f51dd514 for #238)

* Fix `retrying_transaction()` on network errors
  (by @fmoor in cc001e62)

* Fix connection and retry options on `AsyncIOPool` (#237)
  (by @tailhook in 44e279f4 for #237)

* Auto retry read-only queries outside transactions (#243)
  (by @fmoor in 76bb5865 for #243)

* Fix `credentials_file` argument typo on `async_connect` (#252)
  (by @mkniewallner in b21b70ae for #252)