### PR TITLE
safely unpack cached query data for readonly queries retries

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -369,7 +369,7 @@ class AsyncIOConnection(
                 if not e.has_tag(errors.SHOULD_RETRY):
                     raise e
                 if capabilities is None:
-                    _, _, _, capabilities = inner._query_cache.get(
+                    cache_item = inner._query_cache.get(
                         query=query,
                         io_format=io_format,
                         implicit_limit=0,
@@ -377,6 +377,8 @@ class AsyncIOConnection(
                         inline_typeids=False,
                         expect_one=expect_one,
                     )
+                    if cache_item is not None:
+                        _, _, _, capabilities = cache_item
                 # A query is read-only if it has no capabilities i.e.
                 # capabilities == 0. Read-only queries are safe to retry.
                 if capabilities != 0:

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -328,7 +328,7 @@ class BlockingIOConnection(
                 if not e.has_tag(errors.SHOULD_RETRY):
                     raise e
                 if capabilities is None:
-                    _, _, _, capabilities = inner._query_cache.get(
+                    cache_item = inner._query_cache.get(
                         query=query,
                         io_format=io_format,
                         implicit_limit=0,
@@ -336,6 +336,8 @@ class BlockingIOConnection(
                         inline_typeids=False,
                         expect_one=expect_one,
                     )
+                    if cache_item is not None:
+                        _, _, _, capabilities = cache_item
                 # A query is read-only if it has no capabilities i.e.
                 # capabilities == 0. Read-only queries are safe to retry.
                 if capabilities != 0:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -551,6 +551,13 @@ class TestClient(tb.AsyncQueryTestCase):
         await client.aclose()
 
     async def _test_connection_broken(self, executor, broken_evt):
+        broken_evt.set()
+
+        with self.assertRaises(errors.ClientConnectionError):
+            await executor.query_single("SELECT 123")
+
+        broken_evt.clear()
+
         self.assertEqual(await executor.query_single("SELECT 123"), 123)
         broken_evt.set()
         with self.assertRaises(errors.ClientConnectionError):


### PR DESCRIPTION
this fixes an unpacking error, when the EdgeDB server is restarted before the query is parsed, which causes `ClientConnectionError` to be raised and failure to cache query data