### PR TITLE
Retry on transaction conflict errors

### DIFF
--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -379,7 +379,11 @@ class AsyncIOConnection(
                         _, _, _, capabilities = cache_item
                 # A query is read-only if it has no capabilities i.e.
                 # capabilities == 0. Read-only queries are safe to retry.
-                if capabilities != 0:
+                # Explicit transaction conflicts as well.
+                if (
+                    capabilities != 0
+                    and not isinstance(e, errors.TransactionConflictError)
+                ):
                     raise e
                 rule = self._options.retry_options.get_rule_for_exception(e)
                 if i >= rule.attempts:

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -338,7 +338,11 @@ class BlockingIOConnection(
                         _, _, _, capabilities = cache_item
                 # A query is read-only if it has no capabilities i.e.
                 # capabilities == 0. Read-only queries are safe to retry.
-                if capabilities != 0:
+                # Explicit transaction conflicts as well.
+                if (
+                    capabilities != 0
+                    and not isinstance(e, errors.TransactionConflictError)
+                ):
                     raise e
                 rule = self._options.retry_options.get_rule_for_exception(e)
                 if i >= rule.attempts:

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -137,11 +137,9 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
             FILTER .name = 'counter_retry_begin'
         ''')
 
-    @unittest.skip('https://github.com/edgedb/edgedb/issues/2869')
     async def test_async_retry_conflict(self):
         await self.execute_conflict('counter2')
 
-    @unittest.skip('https://github.com/edgedb/edgedb/issues/2869')
     async def test_async_conflict_no_retry(self):
         with self.assertRaises(edgedb.TransactionSerializationError):
             await self.execute_conflict(

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -148,11 +148,9 @@ class TestSyncRetry(tb.SyncQueryTestCase):
             FILTER .name = 'counter_retry_begin'
         ''')
 
-    @unittest.skip('https://github.com/edgedb/edgedb/issues/2869')
     def test_sync_retry_conflict(self):
         self.execute_conflict('counter2')
 
-    @unittest.skip('https://github.com/edgedb/edgedb/issues/2869')
     def test_sync_conflict_no_retry(self):
         with self.assertRaises(edgedb.TransactionSerializationError):
             self.execute_conflict(


### PR DESCRIPTION
The `TransactionConflictError` class of errors is not only safe to
retry, it's _expected_ to be retried, so do that.