### PR TITLE
Update docs to the latest client-based API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,11 +41,11 @@ Basic Usage
     import edgedb
 
     def main():
-        # Establish a connection to an existing database named "test"
+        # Create a client for an existing database named "test"
         # as an "edgedb" user.
-        conn = edgedb.connect('edgedb://edgedb@localhost/test')
+        client = edgedb.create_client('edgedb://edgedb@localhost/test')
         # Create a User object type
-        conn.execute('''
+        client.execute('''
             CREATE TYPE User {
                 CREATE REQUIRED PROPERTY name -> str;
                 CREATE PROPERTY dob -> cal::local_date;
@@ -53,7 +53,7 @@ Basic Usage
         ''')
 
         # Insert a new User object
-        conn.query('''
+        client.query('''
             INSERT User {
                 name := <str>$name,
                 dob := <cal::local_date>$dob
@@ -61,13 +61,13 @@ Basic Usage
         ''', name='Bob', dob=datetime.date(1984, 3, 1))
 
         # Select User objects.
-        user_set = conn.query(
+        user_set = client.query(
             'SELECT User {name, dob} FILTER .name = <str>$name', name='Bob')
         # *user_set* now contains
         # Set{Object{name := 'Bob', dob := datetime.date(1984, 3, 1)}}
 
-        # Close the connection.
-        conn.close()
+        # Close the client.
+        client.close()
 
     if __name__ == '__main__':
         main()

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -82,7 +82,7 @@ Sets
     A representation of an immutable set of values returned by a query.
 
     The :py:meth:`AsyncIOClient.query() <edgedb.AsyncIOClient.query>` and
-    :py:meth:`BlockingIOConnection.query() <edgedb.BlockingIOConnection.query>`
+    :py:meth:`Client.query() <edgedb.Client.query>`
     methods return an instance of this type.  Nested sets in the result are
     also returned as ``Set`` objects.
 
@@ -110,8 +110,8 @@ Objects
     .. code-block:: pycon
 
         >>> import edgedb
-        >>> conn = edgedb.connect()
-        >>> r = conn.query_single('''
+        >>> client = edgedb.create_client()
+        >>> r = client.query_single('''
         ...     SELECT schema::ObjectType {name}
         ...     FILTER .name = 'std::Object'
         ...     LIMIT 1''')
@@ -131,8 +131,8 @@ Objects
        .. code-block:: pycon
 
           >>> import edgedb
-          >>> conn = edgedb.connect()
-          >>> r = conn.query_single('''
+          >>> client = edgedb.create_client()
+          >>> r = client.query_single('''
           ...     SELECT schema::Property {name, annotations: {name, @value}}
           ...     FILTER .name = 'listen_port'
           ...            AND .source.name = 'cfg::Config'
@@ -187,8 +187,8 @@ Tuples
     .. code-block:: pycon
 
         >>> import edgedb
-        >>> conn = edgedb.connect()
-        >>> r = conn.query_single('''SELECT (1, 'a', [3])''')
+        >>> client = edgedb.create_client()
+        >>> r = client.query_single('''SELECT (1, 'a', [3])''')
         >>> r
         (1, 'a', [3])
         >>> len(r)
@@ -212,8 +212,8 @@ Named Tuples
     .. code-block:: pycon
 
         >>> import edgedb
-        >>> conn = edgedb.connect()
-        >>> r = conn.query_single('''SELECT (a := 1, b := 'a', c := [3])''')
+        >>> client = edgedb.create_client()
+        >>> r = client.query_single('''SELECT (a := 1, b := 'a', c := [3])''')
         >>> r
         (a := 1, b := 'a', c := [3])
         >>> r.b
@@ -234,8 +234,8 @@ Arrays
     .. code-block:: pycon
 
         >>> import edgedb
-        >>> conn = edgedb.connect()
-        >>> r = conn.query_single('''SELECT [1, 2, 3]''')
+        >>> client = edgedb.create_client()
+        >>> r = client.query_single('''SELECT [1, 2, 3]''')
         >>> r
         [1, 2, 3]
         >>> len(r)
@@ -255,8 +255,8 @@ RelativeDuration
     .. code-block:: pycon
 
         >>> import edgedb
-        >>> conn = edgedb.connect()
-        >>> r = conn.query_single('''SELECT <cal::relative_duration>"1 year 2 days"''')
+        >>> client = edgedb.create_client()
+        >>> r = client.query_single('''SELECT <cal::relative_duration>"1 year 2 days"''')
         >>> r
         <edgedb.RelativeDuration "P1Y2D">
         >>> r.months

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,6 @@ and :ref:`asyncio <edgedb-python-asyncio-api-reference>` implementations.
 
    installation
    usage
-   api/asyncio_con
-   api/blocking_con
+   api/asyncio_client
+   api/blocking_client
    api/types

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ TEST_DEPENDENCIES = [
 
 # Dependencies required to build documentation.
 DOC_DEPENDENCIES = [
-    'sphinx~=2.3.1',
-    'sphinxcontrib-asyncio~=0.2.0',
-    'sphinx_rtd_theme~=0.4.3',
+    'sphinx~=4.2.0',
+    'sphinxcontrib-asyncio~=0.3.0',
+    'sphinx_rtd_theme~=1.0.0',
 ]
 
 EXTRA_DEPENDENCIES = {


### PR DESCRIPTION
The async and blocking API rst are almost identical now, reflecting the reused pool implementation.