### PR TITLE
Correct edgedb.Client.close() timeout behavior

### DIFF
--- a/edgedb/asyncio_client.py
+++ b/edgedb/asyncio_client.py
@@ -42,7 +42,6 @@ logger = logging.getLogger(__name__)
 
 class AsyncIOConnection(base_client.BaseConnection):
     __slots__ = ("_loop",)
-    _close_exceptions = (Exception, asyncio.CancelledError)
 
     def __init__(self, loop, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -60,6 +59,18 @@ class AsyncIOConnection(base_client.BaseConnection):
 
     async def sleep(self, seconds):
         await asyncio.sleep(seconds)
+
+    async def aclose(self):
+        """Send graceful termination message wait for connection to drop."""
+        if not self.is_closed():
+            try:
+                self._protocol.terminate()
+                await self._protocol.wait_for_disconnect()
+            except (Exception, asyncio.CancelledError):
+                self.terminate()
+                raise
+            finally:
+                self._cleanup()
 
     def _protocol_factory(self):
         return asyncio_proto.AsyncIOProtocol(self._params, self._loop)
@@ -104,7 +115,7 @@ class AsyncIOConnection(base_client.BaseConnection):
             if tr is not None:
                 tr.close()
             raise con_utils.wrap_error(e) from e
-        except Exception:
+        except BaseException:
             if tr is not None:
                 tr.close()
             raise
@@ -125,9 +136,9 @@ class _PoolConnectionHolder(base_client.PoolConnectionHolder):
         if self._con is None:
             return
         if wait:
-            await self._con.close()
+            await self._con.aclose()
         else:
-            self._pool._loop.create_task(self._con.close())
+            self._pool._loop.create_task(self._con.aclose())
 
     async def wait_until_released(self, timeout=None):
         await self._release_event.wait()

--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -42,7 +42,6 @@ class BaseConnection(metaclass=abc.ABCMeta):
     _log_listeners: typing.Set[
         typing.Callable[[BaseConnection_T, errors.EdgeDBMessage], None]
     ]
-    _close_exceptions = (Exception,)
     __slots__ = (
         "__weakref__",
         "_protocol",
@@ -310,18 +309,6 @@ class BaseConnection(metaclass=abc.ABCMeta):
         if not self.is_closed():
             try:
                 self._protocol.abort()
-            finally:
-                self._cleanup()
-
-    async def close(self):
-        """Send graceful termination message wait for connection to drop."""
-        if not self.is_closed():
-            try:
-                self._protocol.terminate()
-                await self._protocol.wait_for_disconnect()
-            except self._close_exceptions:
-                self.terminate()
-                raise
             finally:
                 self._cleanup()
 

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -110,6 +110,23 @@ class BlockingIOConnection(base_client.BaseConnection):
         return not (proto and proto.sock is not None and
                     proto.sock.fileno() >= 0 and proto.connected)
 
+    async def close(self, timeout=None):
+        """Send graceful termination message wait for connection to drop."""
+        if not self.is_closed():
+            try:
+                self._protocol.terminate()
+                if timeout is None:
+                    await self._protocol.wait_for_disconnect()
+                else:
+                    await self._protocol.wait_for(
+                        self._protocol.wait_for_disconnect(), timeout
+                    )
+            except Exception:
+                self.terminate()
+                raise
+            finally:
+                self._cleanup()
+
     def _dispatch_log_message(self, msg):
         for cb in self._log_listeners:
             cb(self, msg)
@@ -119,13 +136,13 @@ class _PoolConnectionHolder(base_client.PoolConnectionHolder):
     __slots__ = ()
     _event_class = threading.Event
 
-    async def close(self, *, wait=True):
+    async def close(self, *, wait=True, timeout=None):
         if self._con is None:
             return
-        await self._con.close()
+        await self._con.close(timeout=timeout)
 
     async def wait_until_released(self, timeout=None):
-        self._release_event.wait(timeout)
+        return self._release_event.wait(timeout)
 
 
 class _PoolImpl(base_client.BasePoolImpl):
@@ -200,17 +217,27 @@ class _PoolImpl(base_client.BasePoolImpl):
             if timeout is None:
                 for ch in self._holders:
                     await ch.wait_until_released()
-            else:
-                remaining = timeout
                 for ch in self._holders:
-                    start = time.monotonic()
-                    await ch.wait_until_released(remaining)
-                    remaining -= time.monotonic() - start
-                    if remaining <= 0:
-                        self.terminate()
-                        return
-            for ch in self._holders:
-                await ch.close()
+                    await ch.close()
+            else:
+                deadline = time.monotonic() + timeout
+                for ch in self._holders:
+                    secs = deadline - time.monotonic()
+                    if secs <= 0:
+                        raise TimeoutError
+                    if not await ch.wait_until_released(secs):
+                        raise TimeoutError
+                for ch in self._holders:
+                    secs = deadline - time.monotonic()
+                    if secs <= 0:
+                        raise TimeoutError
+                    await ch.close(timeout=secs)
+        except TimeoutError as e:
+            self.terminate()
+            raise errors.InterfaceError(
+                "client is not fully closed in {} seconds; "
+                "terminating now.".format(timeout)
+            ) from e
         except Exception:
             self.terminate()
             raise

--- a/edgedb/protocol/asyncio_proto.pyx
+++ b/edgedb/protocol/asyncio_proto.pyx
@@ -20,6 +20,7 @@
 import asyncio
 
 from edgedb import errors
+from edgedb import compat
 from edgedb.pgproto.pgproto cimport (
     WriteBuffer,
     ReadBuffer,

--- a/edgedb/protocol/blocking_proto.pxd
+++ b/edgedb/protocol/blocking_proto.pxd
@@ -26,5 +26,6 @@ cdef class BlockingIOProtocol(protocol.SansIOProtocolBackwardsCompatible):
 
     cdef:
         readonly object sock
+        float deadline
 
     cdef _disconnect(self)

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -184,6 +184,9 @@ cdef class SansIOProtocol:
     async def wait_for_connect(self):
         raise NotImplementedError
 
+    async def wait_for_disconnect(self):
+        raise NotImplementedError
+
     cdef inline ignore_headers(self):
         cdef uint16_t num_fields = <uint16_t>self.buffer.read_int16()
         if self.is_legacy:

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -827,10 +827,9 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
                         fut = asyncio.Future()
 
                         async def exec_to_fail():
-                            with self.assertRaises((
+                            with self.assertRaises(
                                 edgedb.ClientConnectionClosedError,
-                                ConnectionResetError,
-                            )):
+                            ):
                                 async for tx2 in client2.transaction():
                                     async with tx2:
                                         # start the lazy transaction

--- a/tests/test_asyncio_client.py
+++ b/tests/test_asyncio_client.py
@@ -311,9 +311,9 @@ class TestAsyncIOClient(tb.AsyncQueryTestCase):
 
     async def test_client_expire_connections(self):
         class SlowCloseConnection(asyncio_client.AsyncIOConnection):
-            async def close(self):
+            async def close(self, timeout=None):
                 await asyncio.sleep(0.2)
-                await super().close()
+                await super().close(timeout=timeout)
 
         client = self.create_client(
             max_concurrency=1, connection_class=SlowCloseConnection
@@ -335,7 +335,7 @@ class TestAsyncIOClient(tb.AsyncQueryTestCase):
             async with tx:
                 await tx.query("SELECT 42")
                 with self.assertRaises(asyncio.TimeoutError):
-                    await asyncio.wait_for(client.query("SELECT 42"), 1)
+                    await compat.wait_for(client.query("SELECT 42"), 1)
 
         await client.aclose()
 
@@ -445,7 +445,7 @@ class TestAsyncIOClient(tb.AsyncQueryTestCase):
         finally:
             server.close()
             await server.wait_closed()
-            await asyncio.wait_for(client.aclose(), 5)
+            await compat.wait_for(client.aclose(), 5)
             broken.set()
             await done.wait()
 

--- a/tests/test_blocking_client.py
+++ b/tests/test_blocking_client.py
@@ -330,8 +330,9 @@ class TestBlockingClient(tb.SyncQueryTestCase):
         task = threading.Thread(target=worker)
         task.start()
 
-        flag.wait()
-        client.close(timeout=0.1)
+        with self.assertRaises(errors.InterfaceError):
+            flag.wait()
+            client.close(timeout=0.1)
 
         task.join()
 

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -21,8 +21,6 @@ import unittest
 import edgedb
 
 from edgedb import _testbase as tb
-from edgedb import abstract
-from edgedb.protocol import protocol
 
 
 class TestProto(tb.SyncQueryTestCase):
@@ -31,29 +29,6 @@ class TestProto(tb.SyncQueryTestCase):
         self.assertEqual(
             self.client.query_json('SELECT {"aaa", "bbb"}'),
             '["aaa", "bbb"]')
-
-    def test_json_elements(self):
-        self.client.ensure_connected()
-        result = self.client._iter_coroutine(
-            self.client.connection.raw_query(
-                abstract.QueryContext(
-                    query=abstract.QueryWithArgs(
-                        'SELECT {"aaa", "bbb"}', (), {}
-                    ),
-                    cache=self.client._get_query_cache(),
-                    query_options=abstract.QueryOptions(
-                        output_format=protocol.OutputFormat.JSON_ELEMENTS,
-                        expect_one=False,
-                        required_one=False,
-                    ),
-                    retry_options=None,
-                    state=None,
-                )
-            )
-        )
-        self.assertEqual(
-            result,
-            edgedb.Set(['"aaa"', '"bbb"']))
 
     # std::datetime is now in range of Python datetime,
     # so another way to trigger codec failure is needed.

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -16,11 +16,19 @@
 # limitations under the License.
 #
 
+import datetime
+import decimal
 import json
+import random
+import threading
+import time
+import uuid
 
 import edgedb
 
+from edgedb import abstract
 from edgedb import _testbase as tb
+from edgedb.protocol import protocol
 
 
 class TestSyncQuery(tb.SyncQueryTestCase):
@@ -29,6 +37,8 @@ class TestSyncQuery(tb.SyncQueryTestCase):
         CREATE TYPE test::Tmp {
             CREATE REQUIRED PROPERTY tmp -> std::str;
         };
+
+        CREATE SCALAR TYPE MyEnum EXTENDING enum<"A", "B">;
     '''
 
     TEARDOWN = '''
@@ -119,7 +129,7 @@ class TestSyncQuery(tb.SyncQueryTestCase):
             self.client.query('SELECT "HELLO"'),
             ["HELLO"])
 
-    async def test_async_query_single_01(self):
+    def test_sync_query_single_01(self):
         res = self.client.query_single("SELECT 1")
         self.assertEqual(res, 1)
         res = self.client.query_single("SELECT <str>{}")
@@ -321,6 +331,68 @@ class TestSyncQuery(tb.SyncQueryTestCase):
                                     'combine positional and named parameters'):
             self.client.query('select <int64>$0 + <int64>$bar;')
 
+    def test_sync_args_04(self):
+        aware_datetime = datetime.datetime.now(datetime.timezone.utc)
+        naive_datetime = datetime.datetime.now()
+
+        date = datetime.date.today()
+        naive_time = datetime.time(hour=11)
+        aware_time = datetime.time(hour=11, tzinfo=datetime.timezone.utc)
+
+        self.assertEqual(
+            self.client.query_single(
+                'select <datetime>$0;',
+                aware_datetime),
+            aware_datetime)
+
+        self.assertEqual(
+            self.client.query_single(
+                'select <cal::local_datetime>$0;',
+                naive_datetime),
+            naive_datetime)
+
+        self.assertEqual(
+            self.client.query_single(
+                'select <cal::local_date>$0;',
+                date),
+            date)
+
+        self.assertEqual(
+            self.client.query_single(
+                'select <cal::local_time>$0;',
+                naive_time),
+            naive_time)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    r'a timezone-aware.*expected'):
+            self.client.query_single(
+                'select <datetime>$0;',
+                naive_datetime)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    r'a naive time object.*expected'):
+            self.client.query_single(
+                'select <cal::local_time>$0;',
+                aware_time)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    r'a naive datetime object.*expected'):
+            self.client.query_single(
+                'select <cal::local_datetime>$0;',
+                aware_datetime)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    r'datetime.datetime object was expected'):
+            self.client.query_single(
+                'select <cal::local_datetime>$0;',
+                date)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    r'datetime.datetime object was expected'):
+            self.client.query_single(
+                'select <datetime>$0;',
+                date)
+
     def test_sync_mismatched_args_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryArgumentError,
@@ -384,7 +456,383 @@ class TestSyncQuery(tb.SyncQueryTestCase):
 
             self.client.query("""SELECT 42""", a=1, b=2)
 
-    async def test_sync_log_message(self):
+    def test_sync_args_uuid_pack(self):
+        obj = self.client.query_single(
+            'select schema::Object {id, name} limit 1')
+
+        # Test that the custom UUID that our driver uses can be
+        # passed back as a parameter.
+        ot = self.client.query_single(
+            'select schema::Object {name} filter .id=<uuid>$id',
+            id=obj.id)
+        self.assertEqual(obj.id, ot.id)
+        self.assertEqual(obj.name, ot.name)
+
+        # Test that a string UUID is acceptable.
+        ot = self.client.query_single(
+            'select schema::Object {name} filter .id=<uuid>$id',
+            id=str(obj.id))
+        self.assertEqual(obj.id, ot.id)
+        self.assertEqual(obj.name, ot.name)
+
+        # Test that a standard uuid.UUID is acceptable.
+        ot = self.client.query_single(
+            'select schema::Object {name} filter .id=<uuid>$id',
+            id=uuid.UUID(bytes=obj.id.bytes))
+        self.assertEqual(obj.id, ot.id)
+        self.assertEqual(obj.name, ot.name)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'invalid UUID.*length must be'):
+            self.client.query(
+                'select schema::Object {name} filter .id=<uuid>$id',
+                id='asdasas')
+
+    def test_sync_args_bigint_basic(self):
+        testar = [
+            0,
+            -0,
+            +0,
+            1,
+            -1,
+            123,
+            -123,
+            123789,
+            -123789,
+            19876,
+            -19876,
+            19876,
+            -19876,
+            198761239812739812739801279371289371932,
+            -198761182763908473812974620938742386,
+            98761239812739812739801279371289371932,
+            -98761182763908473812974620938742386,
+            8761239812739812739801279371289371932,
+            -8761182763908473812974620938742386,
+            761239812739812739801279371289371932,
+            -761182763908473812974620938742386,
+            61239812739812739801279371289371932,
+            -61182763908473812974620938742386,
+            1239812739812739801279371289371932,
+            -1182763908473812974620938742386,
+            9812739812739801279371289371932,
+            -3908473812974620938742386,
+            98127373373209,
+            -4620938742386,
+            100000000000,
+            -100000000000,
+            10000000000,
+            -10000000000,
+            10000000100,
+            -10000000010,
+            1000000000,
+            -1000000000,
+            100000000,
+            -100000000,
+            10000000,
+            -10000000,
+            1000000,
+            -1000000,
+            100000,
+            -100000,
+            10000,
+            -10000,
+            1000,
+            -1000,
+            100,
+            -100,
+            10,
+            -10,
+        ]
+
+        for _ in range(500):
+            num = ''
+            for _ in range(random.randint(1, 50)):
+                num += random.choice("0123456789")
+            testar.append(int(num))
+
+        for _ in range(500):
+            num = ''
+            for _ in range(random.randint(1, 50)):
+                num += random.choice("0000000012")
+            testar.append(int(num))
+
+        val = self.client.query_single(
+            'select <array<bigint>>$arg',
+            arg=testar)
+
+        self.assertEqual(testar, val)
+
+    def test_sync_args_bigint_pack(self):
+        val = self.client.query_single(
+            'select <bigint>$arg',
+            arg=10)
+        self.assertEqual(val, 10)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query(
+                'select <bigint>$arg',
+                arg='bad int')
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query(
+                'select <bigint>$arg',
+                arg=10.11)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query(
+                'select <bigint>$arg',
+                arg=decimal.Decimal('10.0'))
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query(
+                'select <bigint>$arg',
+                arg=decimal.Decimal('10.11'))
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query(
+                'select <bigint>$arg',
+                arg='10')
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query_single(
+                'select <bigint>$arg',
+                arg=decimal.Decimal('10'))
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            class IntLike:
+                def __int__(self):
+                    return 10
+
+            self.client.query_single(
+                'select <bigint>$arg',
+                arg=IntLike())
+
+    def test_sync_args_intlike(self):
+        class IntLike:
+            def __int__(self):
+                return 10
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query_single(
+                'select <int16>$arg',
+                arg=IntLike())
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query_single(
+                'select <int32>$arg',
+                arg=IntLike())
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected an int'):
+            self.client.query_single(
+                'select <int64>$arg',
+                arg=IntLike())
+
+    def test_sync_args_decimal(self):
+        class IntLike:
+            def __int__(self):
+                return 10
+
+        val = self.client.query_single(
+            'select <decimal>$0', decimal.Decimal("10.0")
+        )
+        self.assertEqual(val, 10)
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected a Decimal or an int'):
+            self.client.query_single(
+                'select <decimal>$arg',
+                arg=IntLike())
+
+        with self.assertRaisesRegex(edgedb.InvalidArgumentError,
+                                    'expected a Decimal or an int'):
+            self.client.query_single(
+                'select <decimal>$arg',
+                arg="10.2")
+
+    def test_sync_wait_cancel_01(self):
+        underscored_lock = self.client.query_single("""
+            SELECT EXISTS(
+                SELECT schema::Function FILTER .name = 'sys::_advisory_lock'
+            )
+        """)
+        if not underscored_lock:
+            self.skipTest("No sys::_advisory_lock function")
+
+        # Test that client protocol handles waits interrupted
+        # by closing.
+        lock_key = tb.gen_lock_key()
+
+        client = self.client.with_retry_options(
+            edgedb.RetryOptions(attempts=1)
+        )
+        client2 = self.make_test_client(
+            database=self.client.dbname
+        ).with_retry_options(
+            edgedb.RetryOptions(attempts=1)
+        ).ensure_connected()
+
+        for tx in client.transaction():
+            with tx:
+                self.assertTrue(tx.query_single(
+                    'select sys::_advisory_lock(<int64>$0)',
+                    lock_key))
+
+                evt = threading.Event()
+
+                def exec_to_fail():
+                    with self.assertRaises((
+                        edgedb.ClientConnectionClosedError,
+                        edgedb.ClientConnectionFailedError,
+                    )):
+                        for tx2 in client2.transaction():
+                            with tx2:
+                                # start the lazy transaction
+                                tx2.query('SELECT 42;')
+                                evt.set()
+
+                                tx2.query(
+                                    'select sys::_advisory_lock(<int64>$0)',
+                                    lock_key,
+                                )
+
+                t = threading.Thread(target=exec_to_fail)
+                t.start()
+
+                try:
+                    evt.wait(1)
+                    time.sleep(0.1)
+
+                    with self.assertRaises(edgedb.InterfaceError):
+                        # close() will ask the server nicely to
+                        # disconnect, but since the server is blocked on
+                        # the lock, close() will timeout and get
+                        # cancelled, which, in turn, will terminate the
+                        # connection rudely, and exec_to_fail() will get
+                        # ConnectionResetError.
+                        client2.close(timeout=0.5)
+                finally:
+                    t.join()
+                    self.assertEqual(
+                        tx.query(
+                            'select sys::_advisory_unlock(<int64>$0)',
+                            lock_key),
+                        [True])
+
+    def test_empty_set_unpack(self):
+        self.client.query_single('''
+          select schema::Function {
+            name,
+            params: {
+              kind,
+            } limit 0,
+            multi setarr := <array<int32>>{}
+          }
+          filter .name = 'std::str_repeat'
+          limit 1
+        ''')
+
+    def test_enum_argument_01(self):
+        A = self.client.query_single('SELECT <MyEnum><str>$0', 'A')
+        self.assertEqual(str(A), 'A')
+
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError, 'invalid input value for enum'
+        ):
+            for tx in self.client.transaction():
+                with tx:
+                    tx.query_single('SELECT <MyEnum><str>$0', 'Oups')
+
+        self.assertEqual(
+            self.client.query_single('SELECT <MyEnum>$0', 'A'),
+            A)
+
+        self.assertEqual(
+            self.client.query_single('SELECT <MyEnum>$0', A),
+            A)
+
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError, 'invalid input value for enum'
+        ):
+            for tx in self.client.transaction():
+                with tx:
+                    tx.query_single('SELECT <MyEnum>$0', 'Oups')
+
+        with self.assertRaisesRegex(
+            edgedb.InvalidArgumentError, 'a str or edgedb.EnumValue'
+        ):
+            self.client.query_single('SELECT <MyEnum>$0', 123)
+
+    def test_json(self):
+        self.assertEqual(
+            self.client.query_json('SELECT {"aaa", "bbb"}'),
+            '["aaa", "bbb"]')
+
+    def test_json_elements(self):
+        self.client.ensure_connected()
+        result = self.client._iter_coroutine(
+            self.client.connection.raw_query(
+                abstract.QueryContext(
+                    query=abstract.QueryWithArgs(
+                        'SELECT {"aaa", "bbb"}', (), {}
+                    ),
+                    cache=self.client._get_query_cache(),
+                    query_options=abstract.QueryOptions(
+                        output_format=protocol.OutputFormat.JSON_ELEMENTS,
+                        expect_one=False,
+                        required_one=False,
+                    ),
+                    retry_options=None,
+                    state=None,
+                )
+            )
+        )
+        self.assertEqual(
+            result,
+            edgedb.Set(['"aaa"', '"bbb"']))
+
+    def _test_sync_cancel_01(self):
+        # TODO(fantix): enable when command_timeout is implemented
+        has_sleep = self.client.query_single("""
+            SELECT EXISTS(
+                SELECT schema::Function FILTER .name = 'sys::_sleep'
+            )
+        """)
+        if not has_sleep:
+            self.skipTest("No sys::_sleep function")
+
+        client = self.make_test_client(database=self.client.dbname)
+
+        try:
+            self.assertEqual(client.query_single('SELECT 1'), 1)
+
+            protocol_before = client._impl._holders[0]._con._protocol
+
+            with self.assertRaises(edgedb.InterfaceError):
+                client.with_timeout_options(command_timeout=0.1).query_single(
+                    'SELECT sys::_sleep(10)'
+                )
+
+            client.query('SELECT 2')
+
+            protocol_after = client._impl._holders[0]._con._protocol
+            self.assertIsNot(
+                protocol_before, protocol_after, "Reconnect expected"
+            )
+        finally:
+            client.close()
+
+    def test_sync_log_message(self):
         msgs = []
 
         def on_log(con, msg):
@@ -407,3 +855,16 @@ class TestSyncQuery(tb.SyncQueryTestCase):
                 break
         else:
             raise AssertionError('a notice message was not delivered')
+
+    def test_sync_banned_transaction(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            r'cannot execute transaction control commands',
+        ):
+            self.client.query('start transaction')
+
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            r'cannot execute transaction control commands',
+        ):
+            self.client.execute('start transaction')


### PR DESCRIPTION
Also added tests in test_sync_query.py, and use only sync client in
sync_* tests.

This is a part of #289