### PR TITLE
Remove DSN from `create_client()`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,7 @@ Basic Usage
     import edgedb
 
     def main():
-        # Create a client for an existing database named "test"
-        # as an "edgedb" user.
-        client = edgedb.create_client('edgedb://edgedb@localhost/test')
+        client = edgedb.create_client()
         # Create a User object type
         client.execute('''
             CREATE TYPE User {


### PR DESCRIPTION
The idiomatic way to connect to instances is without any arguments and
rely on auto-discovery.