### PR TITLE
improve error when passing empty query arguments

### DIFF
--- a/edgedb/protocol/codecs/object.pyx
+++ b/edgedb/protocol/codecs/object.pyx
@@ -85,7 +85,9 @@ cdef class ObjectCodec(BaseNamedRecordCodec):
         extra_args = passed_args - required_args
 
         error_message = f'expected {required_args} arguments'
-        error_message += f', got {passed_args}'
+
+        passed_args_repr = repr(passed_args) if passed_args else 'nothing'
+        error_message += f', got {passed_args_repr}'
 
         missed_args = set(required_args) - set(passed_args)
         if missed_args:

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -582,6 +582,15 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
 
             await self.client.query("""SELECT <int64>$a;""", a=1, b=2)
 
+    async def test_async_mismatched_args_06(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryArgumentError,
+                r"expected {'a'} arguments, "
+                r"got nothing, "
+                r"missed {'a'}"):
+
+            await self.client.query("""SELECT <int64>$a;""")
+
     async def test_async_args_uuid_pack(self):
         obj = await self.client.query_single(
             'select schema::Object {id, name} limit 1')

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -433,6 +433,15 @@ class TestSyncQuery(tb.SyncQueryTestCase):
 
             self.client.query("""SELECT <int64>$a;""", a=1, b=2)
 
+    def test_sync_mismatched_args_06(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryArgumentError,
+                r"expected {'a'} arguments, "
+                r"got nothing, "
+                r"missed {'a'}"):
+
+            self.client.query("""SELECT <int64>$a;""")
+
     async def test_sync_log_message(self):
         msgs = []
 


### PR DESCRIPTION
Quite a small change to show `nothing` instead of python's `set()` when query requires something but user hasn't provided anything.

Also protocol `0.12` has been stable for a while. Maybe driver should get rid of arguments encoding with named tuple codec + remove that part from tests?
