### PR TITLE
Stop using Parse, replace use of headers with fields

### DIFF
--- a/edgedb/enums.py
+++ b/edgedb/enums.py
@@ -3,12 +3,18 @@ import enum
 
 class Capability(enum.IntFlag):
 
+    NONE              = 0         # noqa
     MODIFICATIONS     = 1 << 0    # noqa
     SESSION_CONFIG    = 1 << 1    # noqa
     TRANSACTION       = 1 << 2    # noqa
     DDL               = 1 << 3    # noqa
     PERSISTENT_CONFIG = 1 << 4    # noqa
 
+    ALL               = 0xFFFF_FFFF_FFFF_FFFF  # noqa
+    EXECUTE           = ALL & ~TRANSACTION     # noqa
 
-Capability.ALL = 0xFFFF_FFFF_FFFF_FFFF
-Capability.EXECUTE = Capability.ALL & ~Capability.TRANSACTION
+
+class CompilationFlag(enum.IntFlag):
+
+    INJECT_OUTPUT_TYPE_IDS   = 1 << 0    # noqa
+    INJECT_OUTPUT_TYPE_NAMES = 1 << 1    # noqa

--- a/edgedb/protocol/codecs/base.pyx
+++ b/edgedb/protocol/codecs/base.pyx
@@ -25,6 +25,7 @@ cdef uint64_t RECORD_ENCODER_INVALID = 1 << 1
 
 cdef bytes NULL_CODEC_ID = b'\x00' * 16
 cdef bytes EMPTY_TUPLE_CODEC_ID = TYPE_IDS.get('empty-tuple').bytes
+cdef bytes INVALID_CODEC_ID = b'\xff' * 16
 
 EMPTY_NULL_DATA = b'\x00\x00\x00\x00'
 EMPTY_RECORD_DATA = b'\x00\x00\x00\x04\x00\x00\x00\x00'
@@ -112,6 +113,13 @@ cdef class EmptyTupleCodec(BaseCodec):
         if self.empty_tup is None:
             self.empty_tup = datatypes.tuple_new(0)
         return self.empty_tup
+
+
+cdef class InvalidCodec(BaseCodec):
+
+    def __cinit__(self):
+        self.tid = INVALID_CODEC_ID
+        self.name = 'invalid-codec'
 
 
 cdef class NullCodec(BaseCodec):

--- a/edgedb/protocol/codecs/codecs.pyx
+++ b/edgedb/protocol/codecs/codecs.pyx
@@ -51,6 +51,7 @@ DEF NBASE = 10000
 DEF NUMERIC_POS = 0x0000
 DEF NUMERIC_NEG = 0x4000
 
+cdef BaseCodec INVALID_CODEC = InvalidCodec.__new__(InvalidCodec)
 cdef BaseCodec NULL_CODEC = NullCodec.__new__(NullCodec)
 cdef BaseCodec EMPTY_TUPLE_CODEC = EmptyTupleCodec.__new__(EmptyTupleCodec)
 

--- a/edgedb/protocol/protocol_v0.pxd
+++ b/edgedb/protocol/protocol_v0.pxd
@@ -17,4 +17,5 @@
 #
 
 cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
-    pass
+    cdef parse_legacy_describe_type_message(self, CodecsRegistry reg)
+    cdef parse_legacy_command_complete_message(self)


### PR DESCRIPTION
This makes these changes to the 1.0 protocol:

1. We no longer use Parse and instead rely on Execute semantics
2. We no longer rely on message headers to pass material information
   that affects how the message is processed.  These are now proper
   fields on messages.
3. We use a known-invalid typedesc id to force Parse behavior from
   Execute.