### PR TITLE
Explicitly enable object id injection

### DIFF
--- a/edgedb/enums.py
+++ b/edgedb/enums.py
@@ -18,3 +18,4 @@ class CompilationFlag(enum.IntFlag):
 
     INJECT_OUTPUT_TYPE_IDS   = 1 << 0    # noqa
     INJECT_OUTPUT_TYPE_NAMES = 1 << 1    # noqa
+    INJECT_OUTPUT_OBJECT_IDS = 1 << 2    # noqa

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -229,7 +229,7 @@ cdef class SansIOProtocol:
             object result
             bytes new_cardinality = None
 
-        compilation_flags = 0
+        compilation_flags = enums.CompilationFlag.INJECT_OUTPUT_OBJECT_IDS
         if inline_typenames:
             compilation_flags |= enums.CompilationFlag.INJECT_OUTPUT_TYPE_NAMES
         if inline_typeids:


### PR DESCRIPTION
Protocol 1 now requires an explicit flag to enable auto-injection of
object ids into output shapes