### PR TITLE
Skip Parse if no args provided

### DIFF
--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -146,7 +146,6 @@ cdef class SansIOProtocol:
         str query,
         object output_format,
         bint expect_one,
-        bint required_one,
         int implicit_limit,
         bint inline_typenames,
         bint inline_typeids,

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -372,10 +372,7 @@ cdef class SansIOProtocol:
         buf.write_bytes(in_dc.get_tid())
         buf.write_bytes(out_dc.get_tid())
 
-        if not isinstance(in_dc, NullCodec):
-            self.encode_args(in_dc, buf, args, kwargs)
-        else:
-            buf.write_bytes(EMPTY_NULL_DATA)
+        self.encode_args(in_dc, buf, args, kwargs)
 
         buf.end_message()
 

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -211,7 +211,6 @@ cdef class SansIOProtocol:
         str query,
         object output_format,
         bint expect_one,
-        bint required_one,
         int implicit_limit,
         bint inline_typenames,
         bint inline_typeids,
@@ -275,7 +274,6 @@ cdef class SansIOProtocol:
             query=query,
             output_format=output_format,
             expect_one=expect_one,
-            required_one=required_one,
             implicit_limit=implicit_limit,
             inline_typenames=inline_typenames,
             inline_typeids=inline_typeids,
@@ -359,7 +357,6 @@ cdef class SansIOProtocol:
             query=query,
             output_format=output_format,
             expect_one=expect_one,
-            required_one=required_one,
             implicit_limit=implicit_limit,
             inline_typenames=inline_typenames,
             inline_typeids=inline_typeids,
@@ -381,8 +378,6 @@ cdef class SansIOProtocol:
             buf.write_bytes(EMPTY_NULL_DATA)
 
         buf.end_message()
-
-        in_tid = in_dc.get_tid()
 
         packet = WriteBuffer.new()
         packet.write_buffer(buf)
@@ -1059,9 +1054,6 @@ cdef class SansIOProtocol:
                 f'unexpected message type {chr(mtype)!r}')
 
     cdef encode_args(self, BaseCodec in_dc, WriteBuffer buf, args, kwargs):
-        cdef:
-             WriteBuffer tmp = WriteBuffer.new()
-
         if args and kwargs:
             raise errors.QueryArgumentError(
                 'either positional or named arguments are supported; '

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -528,6 +528,14 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
 
             await self.client.query("""SELECT <int64>$a;""")
 
+    async def test_async_mismatched_args_07(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryArgumentError,
+            "expected no named arguments",
+        ):
+
+            await self.client.query("""SELECT 42""", a=1, b=2)
+
     async def test_async_args_uuid_pack(self):
         obj = await self.client.query_single(
             'select schema::Object {id, name} limit 1')

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -376,6 +376,14 @@ class TestSyncQuery(tb.SyncQueryTestCase):
 
             self.client.query("""SELECT <int64>$a;""")
 
+    def test_sync_mismatched_args_07(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryArgumentError,
+            "expected no named arguments",
+        ):
+
+            self.client.query("""SELECT 42""", a=1, b=2)
+
     async def test_sync_log_message(self):
         msgs = []
 


### PR DESCRIPTION
This optimization saves one round trip for executing (except for the `query_required_single*()` family) uncached commands without args.

Also fixed a regression to raise error if arguments are given when none is expected.