### PR TITLE
Docs: document transaction/retry options and state

### DIFF
--- a/docs/api/advanced.rst
+++ b/docs/api/advanced.rst
@@ -1,0 +1,196 @@
+.. _edgedb-python-advanced:
+
+==============
+Advanced Usage
+==============
+
+.. py:currentmodule:: edgedb
+
+
+.. _edgedb-python-transaction-options:
+
+Transaction Options
+===================
+
+Transactions can be customized with different options:
+
+.. py:class:: TransactionOptions(isolation=IsolationLevel.Serializable, readonly=False, deferrable=False)
+
+    :param IsolationLevel isolation: transaction isolation level
+    :param bool readonly: if true the transaction will be readonly
+    :param bool deferrable: if true the transaction will be deferrable
+
+    .. py:method:: defaults()
+        :classmethod:
+
+        Returns the default :py:class:`TransactionOptions`.
+
+.. py:class:: IsolationLevel
+
+    Isolation level for transaction
+
+    .. py:attribute:: Serializable
+
+        Serializable isolation level
+
+:py:class:`TransactionOptions` can be set on :py:class:`~edgedb.Client` or
+:py:class:`~edgedb.AsyncIOClient` using one of these methods:
+
+* :py:meth:`edgedb.Client.with_transaction_options`
+* :py:meth:`edgedb.AsyncIOClient.with_transaction_options`
+
+These methods return a "shallow copy" of the current client object with modified
+transaction options. Both ``self`` and the returned object can be used, but
+different transaction options will applied respectively.
+
+Transaction options are used by the future calls to the method
+:py:meth:`edgedb.Client.transaction` or :py:meth:`edgedb.AsyncIOClient.transaction`.
+
+
+.. _edgedb-python-retry-options:
+
+Retry Options
+=============
+
+Individual EdgeQL commands or whole transaction blocks are automatically retried on
+retryable errors. By default, edgedb-python will try at most 3 times, with an
+exponential backoff time interval starting from 100ms, plus a random hash under 100ms.
+
+Retry rules can be granularly customized with different retry options:
+
+.. py:class:: RetryOptions(attempts, backoff=default_backoff)
+
+    :param int attempts: the default number of attempts
+    :param Callable[[int], Union[float, int]] backoff: the default backoff function
+
+    .. py:method:: with_rule(condition, attempts=None, backoff=None)
+
+        Adds a backoff rule for a particular condition
+
+        :param RetryCondition condition: condition that will trigger this rule
+        :param int attempts: number of times to retry
+        :param Callable[[int], Union[float, int]] backoff:
+          function taking the current attempt number and returning the number
+          of seconds to wait before the next attempt
+
+    .. py:method:: defaults()
+        :classmethod:
+
+        Returns the default :py:class:`RetryOptions`.
+
+.. py:class:: RetryCondition
+
+    Specific condition to retry on for fine-grained control
+
+    .. py:attribute:: TransactionConflict
+
+        Triggered when a TransactionConflictError occurs.
+
+    .. py:attribute:: NetworkError
+
+        Triggered when a ClientError occurs.
+
+:py:class:`RetryOptions` can be set on :py:class:`~edgedb.Client` or
+:py:class:`~edgedb.AsyncIOClient` using one of these methods:
+
+* :py:meth:`edgedb.Client.with_retry_options`
+* :py:meth:`edgedb.AsyncIOClient.with_retry_options`
+
+These methods return a "shallow copy" of the current client object with modified
+retry options. Both ``self`` and the returned object can be used, but different
+retry options will applied respectively.
+
+
+.. _edgedb-python-state:
+
+State
+=====
+
+State is an execution context that affects the execution of EdgeQL commands in
+different ways: default module, module aliases, session config and global values.
+
+.. py:class:: State(module=None, aliases={}, config={}, globals_={})
+
+    :type module: str or None
+    :param module:
+        The *default module* that the future commands will be executed with.
+        ``None`` means the default *default module* on the server-side,
+        which is usually just ``default``.
+
+    :param dict[str, str] aliases:
+        Module aliases mapping of alias -> target module.
+
+    :param dict[str, object] config:
+        Non system-level config settings mapping of config name -> config value.
+
+        For available configuration parameters refer to the
+        :ref:`Config documentation <ref_std_cfg>`.
+
+    :param dict[str, object] globals_:
+        Global values mapping of global name -> global value.
+
+        Note, the global name can be either a qualified name like
+        ``my_mod::glob2``, or a simple name under the default module. Simple
+        names will be prefixed with the default module at execution time.
+        Values under different types of names for the same global would
+        overwrite each other, so try not to do that.
+
+    .. py:method:: with_module_aliases(module=..., **aliases)
+
+        Returns a new :py:class`State` copy with adjusted default module and/or
+        module aliases.
+
+        :type module: str or None
+        :param module:
+            Adjust the *default module*. If ``module`` is not set, the default
+            behavior is not to adjust the *default module* in the copy.
+
+            This is equivalent to using the ``set module`` command.
+
+        :param dict[str, str] aliases:
+            Adjust the module aliases by merging with the given alias -> target
+            module mapping.
+
+            This is equivalent to using the ``set alias`` command.
+
+    .. py:method:: with_config(**config)
+
+        Returns a new :py:class:`State` copy with adjusted session config.
+
+        This is equivalent to using the ``configure session`` command.
+
+        :param dict[str, object] config:
+            Adjust the config settings by merging with the given config name ->
+            config value mapping.
+
+    .. py:method:: with_globals(**globals_)
+
+        Returns a new :py:class:`State` copy with adjusted global values.
+
+        This is equivalent to using the ``set global`` command.
+
+        :param dict[str, object] globals_:
+            Adjust the global values by merging with the given global name ->
+            global value mapping.
+
+:py:class:`State` can be set on :py:class:`~edgedb.Client` or
+:py:class:`~edgedb.AsyncIOClient` using one of these methods:
+
+* :py:meth:`edgedb.Client.with_state`
+* :py:meth:`edgedb.AsyncIOClient.with_state`
+
+These methods return a "shallow copy" of the current client object with modified
+state, affecting all future commands executed using the returned copy.
+Both ``self`` and the returned object can be used, but different state will
+applied respectively.
+
+Alternatively, shortcuts are available on client objects:
+
+* :py:meth:`edgedb.Client.with_module_aliases`
+* :py:meth:`edgedb.Client.with_config`
+* :py:meth:`edgedb.Client.with_globals`
+* :py:meth:`edgedb.AsyncIOClient.with_module_aliases`
+* :py:meth:`edgedb.AsyncIOClient.with_config`
+* :py:meth:`edgedb.AsyncIOClient.with_globals`
+
+They work the same way as ``with_state``, and adjusts the corresponding state values.

--- a/docs/api/asyncio_client.rst
+++ b/docs/api/asyncio_client.rst
@@ -381,6 +381,68 @@ Client
         mis-configuration by triggering the first connection attempt
         explicitly.
 
+    .. py:method:: with_transaction_options(options=None)
+
+        Returns a shallow copy of the client with adjusted transaction options.
+
+        :param TransactionOptions options:
+            Object that encapsulates transaction options.
+
+        See :ref:`edgedb-python-transaction-options` for details.
+
+    .. py:method:: with_retry_options(options=None)
+
+        Returns a shallow copy of the client with adjusted retry options.
+
+        :param RetryOptions options: Object that encapsulates retry options.
+
+        See :ref:`edgedb-python-retry-options` for details.
+
+    .. py:method:: with_state(state)
+
+        Returns a shallow copy of the client with adjusted state.
+
+        :param State state: Object that encapsulates state.
+
+        See :ref:`edgedb-python-state` for details.
+
+    .. py:method:: with_module_aliases(module=..., **aliases)
+
+        Returns a shallow copy of the client with adjusted default module and/or
+        module aliases.
+
+        :type module: str or None
+        :param module:
+            Adjust the *default module*. If ``module`` is not set, the default
+            behavior is not to adjust the *default module* in the copy.
+
+            This is equivalent to using the ``set module`` command.
+
+        :param dict[str, str] aliases:
+            Adjust the module aliases by merging with the given alias -> target
+            module mapping.
+
+            This is equivalent to using the ``set alias`` command.
+
+    .. py:method:: with_config(**config)
+
+        Returns a shallow copy of the client with adjusted session config.
+
+        This is equivalent to using the ``configure session`` command.
+
+        :param dict[str, object] config:
+            Adjust the config settings by merging with the given config name ->
+            config value mapping.
+
+    .. py:method:: with_globals(**globals_)
+
+        Returns a shallow copy of the client with adjusted global values.
+
+        This is equivalent to using the ``set global`` command.
+
+        :param dict[str, object] globals_:
+            Adjust the global values by merging with the given global name ->
+            global value mapping.
 
 .. _edgedb-python-asyncio-api-transaction:
 

--- a/docs/api/blocking_client.rst
+++ b/docs/api/blocking_client.rst
@@ -379,32 +379,67 @@ Client
 
     .. py:method:: with_transaction_options(options=None)
 
-        Returns object with adjusted options for future transactions.
+        Returns a shallow copy of the client with adjusted transaction options.
 
         :param TransactionOptions options:
             Object that encapsulates transaction options.
 
-        This method returns a "shallow copy" of the current object
-        with modified transaction options.
-
-        Both ``self`` and returned object can be used after, but when using
-        them transaction options applied will be different.
-
-        Transaction options are used by the
-        :py:meth:`~edgedb.Client.transaction` method.
+        See :ref:`edgedb-python-transaction-options` for details.
 
     .. py:method:: with_retry_options(options=None)
 
-        Returns object with adjusted options for future retrying
-        transactions.
+        Returns a shallow copy of the client with adjusted retry options.
 
         :param RetryOptions options: Object that encapsulates retry options.
 
-        This method returns a "shallow copy" of the current object
-        with modified retry options.
+        See :ref:`edgedb-python-retry-options` for details.
 
-        Both ``self`` and returned object can be used after, but when using
-        them transaction options applied will be different.
+    .. py:method:: with_state(state)
+
+        Returns a shallow copy of the client with adjusted state.
+
+        :param State state: Object that encapsulates state.
+
+        See :ref:`edgedb-python-state` for details.
+
+    .. py:method:: with_module_aliases(module=..., **aliases)
+
+        Returns a shallow copy of the client with adjusted default module and/or
+        module aliases.
+
+        :type module: str or None
+        :param module:
+            Adjust the *default module*. If ``module`` is not set, the default
+            behavior is not to adjust the *default module* in the copy.
+
+            This is equivalent to using the ``set module`` command.
+
+        :param dict[str, str] aliases:
+            Adjust the module aliases by merging with the given alias -> target
+            module mapping.
+
+            This is equivalent to using the ``set alias`` command.
+
+    .. py:method:: with_config(**config)
+
+        Returns a shallow copy of the client with adjusted session config.
+
+        This is equivalent to using the ``configure session`` command.
+
+        :param dict[str, object] config:
+            Adjust the config settings by merging with the given config name ->
+            config value mapping.
+
+    .. py:method:: with_globals(**globals_)
+
+        Returns a shallow copy of the client with adjusted global values.
+
+        This is equivalent to using the ``set global`` command.
+
+        :param dict[str, object] globals_:
+            Adjust the global values by merging with the given global name ->
+            global value mapping.
+
 
 .. _edgedb-python-blocking-api-transaction:
 
@@ -595,55 +630,5 @@ See also:
         Yields :py:class:`Transaction` object every time transaction has to
         be repeated.
 
-.. py:class:: RetryOptions(attempts, backoff=default_backoff)
-
-    An immutable class that contains rules for :py:meth:`Client.transaction()`
-
-    :param int attempts: the default number of attempts
-    :param Callable[[int], Union[float, int]] backoff: the default backoff function
-
-    .. py:method:: with_rule(condition, attempts=None, backoff=None)
-
-        Adds a backoff rule for a particular condition
-
-        :param RetryCondition condition: condition that will trigger this rule
-        :param int attempts: number of times to retry
-        :param Callable[[int], Union[float, int]] backoff:
-          function taking the current attempt number and returning the number
-          of seconds to wait before the next attempt
-
-    .. py:method:: defaults()
-        :classmethod:
-
-        Returns the default :py:class:`RetryOptions`.
-
-.. py:class:: RetryCondition
-
-    Specific condition to retry on for fine-grained control
-
-    .. py:attribute:: TransactionConflict
-
-        Triggered when a TransactionConflictError occurs.
-
-    .. py:attribute:: NetworkError
-
-        Triggered when a ClientError occurs.
-
-.. py:class:: TransactionOptions(isolation=IsolationLevel.Serializable, readonly=False, deferrable=False)
-
-    Options for :py:meth:`Client.transaction()`
-
-    :param IsolationLevel isolation: transaction isolation level
-    :param bool readonly: if true the transaction will be readonly
-    :param bool deferrable: if true the transaction will be deferrable
-
-
-.. py:class:: IsolationLevel
-
-    Isolation level for transaction
-
-    .. py:attribute:: Serializable
-
-        Serializable isolation level
 
 .. _RFC1004: https://github.com/edgedb/rfcs/blob/master/text/1004-transactions-api.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,10 @@ and :ref:`asyncio <edgedb-python-asyncio-api-reference>` implementations.
 
   EdgeDB Python types documentation.
 
+* :ref:`edgedb-python-advanced`
+
+  Advanced usages of the state and optional customization.
+
 
 .. toctree::
    :maxdepth: 3
@@ -42,3 +46,4 @@ and :ref:`asyncio <edgedb-python-asyncio-api-reference>` implementations.
    api/asyncio_client
    api/blocking_client
    api/types
+   api/advanced

--- a/edgedb/options.py
+++ b/edgedb/options.py
@@ -206,7 +206,7 @@ class _OptionsMixin:
         Both ``self`` and returned object can be used after, but when using
         them transaction options applied will be different.
 
-        Transaction options are are used by the ``transaction`` method.
+        Transaction options are used by the ``transaction`` method.
         """
         result = self._shallow_clone()
         result._options = self._options.with_transaction_options(options)
@@ -223,7 +223,7 @@ class _OptionsMixin:
         with modified retry options.
 
         Both ``self`` and returned object can be used after, but when using
-        them transaction options applied will be different.
+        them retry options applied will be different.
         """
 
         result = self._shallow_clone()


### PR DESCRIPTION
This PR also fixed an issue that async client didn't document about `with_transaction_options()` and `with_retry_options()`, by moving those from the blocking client into a shared separate page "Advanced Usage", together with adding the new `with_state()` and friends content.