### PR TITLE
Disable tests on Windows for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         edgedb-version: [stable , nightly]
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest]
         loop: [asyncio, uvloop]
         exclude:
           # uvloop does not support Python 3.6


### PR DESCRIPTION
The Windows environment seems to be having trouble running EdgeDB in
WSL1 even on `windows-2019` version now, so disable Windows tests until
we find a solution.