### PR TITLE
Recover from failed COMMIT

### DIFF
--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -139,6 +139,9 @@ class BaseTransaction:
                 await self._privileged_execute(query)
             except BaseException:
                 self._state = TransactionState.FAILED
+                if extype is None:
+                    # COMMIT itself may fail; recover in connection
+                    await self._privileged_execute("ROLLBACK;")
                 raise
             else:
                 self._state = state

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -82,3 +82,10 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
             async for tx in client.transaction():
                 async with tx:
                     pass
+
+    async def test_async_transaction_commit_failure(self):
+        with self.assertRaises(edgedb.errors.QueryError):
+            async for tx in self.client.transaction():
+                async with tx:
+                    await tx.execute("start migration to {};")
+        self.assertEqual(await self.client.query_single("select 42"), 42)

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -90,3 +90,10 @@ class TestSyncTx(tb.SyncQueryTestCase):
             for tx in client.transaction():
                 with tx:
                     pass
+
+    def test_sync_transaction_commit_failure(self):
+        with self.assertRaises(edgedb.errors.QueryError):
+            for tx in self.client.transaction():
+                with tx:
+                    tx.execute("start migration to {};")
+        self.assertEqual(self.client.query_single("select 42"), 42)


### PR DESCRIPTION
If `COMMIT` fails, run `ROLLBACK` to save the connection.