### PR TITLE
edgedb-python 0.24.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.24.0a7'
+__version__ = '0.24.0'


### PR DESCRIPTION
Changes
=======

* Remove DSN from `create_client()`
  (by @elprans in 90811058 for #303)

* Add support for protocol v1.0
  (by @fantix in 51344fe9 for #306)

* improve error when passing empty query arguments
  (by @nsidnev in 7a393ec5)

* Accept args in execute() and use the new Execute message
  (by @fantix in 52987010 for #310)

* drop legacy agruments encoding with named tuple codec
  (by @nsidnev in ef96e763)

* Stop using Parse, replace use of headers with fields
  (by @elprans in b2c9e4bf)

* Change headers format to str:json
  (by @fantix in f17a4fd3 for #319)

* Document rolling back a transaction
  (by @fmoor in 266f18be)

* Support EDGEDB_WAIT_UNTIL_AVAILABLE environment variable
  (by @fmoor in c27ab361)

* Add `with_globals()` and friends through state over the protocol
  (by @fantix in 8582ec14 for #315)

* Implement support for range types
  (by @elprans in a415b9f2 for #332)

* Implement support for cal::date_duration
  (by @elprans in e77615b7 for #335)

* Recover from failed COMMIT
  (by @fantix in 9f09e78e)

* Allow <array<range<T>>> arguments
  (by @fmoor in 243250cf for #351)