### PR TITLE
Implement dataclass for EdgeObject

### DIFF
--- a/edgedb/datatypes/datatypes.h
+++ b/edgedb/datatypes/datatypes.h
@@ -59,6 +59,7 @@ typedef struct {
     EdgeRecordFieldDesc *descs;
     Py_ssize_t idpos;
     Py_ssize_t size;
+    PyObject *get_dataclass_fields;
 } EdgeRecordDescObject;
 
 typedef enum {
@@ -82,6 +83,7 @@ EdgeFieldCardinality EdgeRecordDesc_PointerCardinality(PyObject *, Py_ssize_t);
 Py_ssize_t EdgeRecordDesc_GetSize(PyObject *);
 edge_attr_lookup_t EdgeRecordDesc_Lookup(PyObject *, PyObject *, Py_ssize_t *);
 PyObject * EdgeRecordDesc_List(PyObject *, uint8_t, uint8_t);
+PyObject * EdgeRecordDesc_GetDataclassFields(PyObject *);
 
 
 

--- a/edgedb/datatypes/datatypes.h
+++ b/edgedb/datatypes/datatypes.h
@@ -59,7 +59,7 @@ typedef struct {
     EdgeRecordFieldDesc *descs;
     Py_ssize_t idpos;
     Py_ssize_t size;
-    PyObject *get_dataclass_fields;
+    PyObject *get_dataclass_fields_func;
 } EdgeRecordDescObject;
 
 typedef enum {

--- a/edgedb/datatypes/object.c
+++ b/edgedb/datatypes/object.c
@@ -375,7 +375,8 @@ EdgeObject_InitType(void)
         return NULL;
     }
 
-    // Pass the `dataclasses.is_dataclass(obj)` check, the dict is always empty
+    // Pass the `dataclasses.is_dataclass(obj)` check - which then checks
+    // `hasattr(type(obj), "__dataclass_fields__")`, the dict is always empty
     PyObject *default_fields = PyDict_New();
     if (default_fields == NULL) {
         return NULL;

--- a/edgedb/datatypes/record_desc.c
+++ b/edgedb/datatypes/record_desc.c
@@ -181,7 +181,7 @@ record_desc_dir(EdgeRecordDescObject *o, PyObject *args)
 static PyObject *
 record_set_dataclass_fields_func(EdgeRecordDescObject *o, PyObject *arg)
 {
-    o->get_dataclass_fields = arg;
+    o->get_dataclass_fields_func = arg;
     Py_INCREF(arg);
     Py_RETURN_NONE;
 }

--- a/edgedb/datatypes/record_desc.c
+++ b/edgedb/datatypes/record_desc.c
@@ -559,7 +559,12 @@ EdgeRecordDesc_GetDataclassFields(PyObject *ob)
 
     EdgeRecordDescObject *o = (EdgeRecordDescObject *)ob;
 
+// bpo-37194 added PyObject_CallNoArgs() to Python 3.9.0a1
+#if PY_VERSION_HEX < 0x030900A1
+    return PyObject_CallFunctionObjArgs(o->get_dataclass_fields, NULL);
+#else
     return PyObject_CallNoArgs(o->get_dataclass_fields);
+#endif
 }
 
 

--- a/edgedb/datatypes/record_desc.c
+++ b/edgedb/datatypes/record_desc.c
@@ -30,7 +30,7 @@ record_desc_dealloc(EdgeRecordDescObject *o)
     PyObject_GC_UnTrack(o);
     Py_CLEAR(o->index);
     Py_CLEAR(o->names);
-    Py_CLEAR(o->get_dataclass_fields);
+    Py_CLEAR(o->get_dataclass_fields_func);
     PyMem_RawFree(o->descs);
     PyObject_GC_Del(o);
 }
@@ -181,6 +181,7 @@ record_desc_dir(EdgeRecordDescObject *o, PyObject *args)
 static PyObject *
 record_set_dataclass_fields_func(EdgeRecordDescObject *o, PyObject *arg)
 {
+    Py_CLEAR(o->get_dataclass_fields_func);
     o->get_dataclass_fields_func = arg;
     Py_INCREF(arg);
     Py_RETURN_NONE;
@@ -561,9 +562,9 @@ EdgeRecordDesc_GetDataclassFields(PyObject *ob)
 
 // bpo-37194 added PyObject_CallNoArgs() to Python 3.9.0a1
 #if PY_VERSION_HEX < 0x030900A1
-    return PyObject_CallFunctionObjArgs(o->get_dataclass_fields, NULL);
+    return PyObject_CallFunctionObjArgs(o->get_dataclass_fields_func, NULL);
 #else
-    return PyObject_CallNoArgs(o->get_dataclass_fields);
+    return PyObject_CallNoArgs(o->get_dataclass_fields_func);
 #endif
 }
 

--- a/edgedb/datatypes/record_desc.c
+++ b/edgedb/datatypes/record_desc.c
@@ -362,6 +362,7 @@ EdgeRecordDesc_New(PyObject *names, PyObject *flags, PyObject *cards)
 
     o->size = size;
     o->idpos = idpos;
+    o->get_dataclass_fields_func = NULL;
 
     PyObject_GC_Track(o);
     return (PyObject *)o;

--- a/edgedb/datatypes/record_desc.c
+++ b/edgedb/datatypes/record_desc.c
@@ -30,6 +30,7 @@ record_desc_dealloc(EdgeRecordDescObject *o)
     PyObject_GC_UnTrack(o);
     Py_CLEAR(o->index);
     Py_CLEAR(o->names);
+    Py_CLEAR(o->get_dataclass_fields);
     PyMem_RawFree(o->descs);
     PyObject_GC_Del(o);
 }
@@ -177,12 +178,23 @@ record_desc_dir(EdgeRecordDescObject *o, PyObject *args)
 }
 
 
+static PyObject *
+record_set_dataclass_fields_func(EdgeRecordDescObject *o, PyObject *arg)
+{
+    o->get_dataclass_fields = arg;
+    Py_INCREF(arg);
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef record_desc_methods[] = {
     {"is_linkprop", (PyCFunction)record_desc_is_linkprop, METH_O, NULL},
     {"is_link", (PyCFunction)record_desc_is_link, METH_O, NULL},
     {"is_implicit", (PyCFunction)record_desc_is_implicit, METH_O, NULL},
     {"get_pos", (PyCFunction)record_desc_get_pos, METH_O, NULL},
     {"__dir__", (PyCFunction)record_desc_dir, METH_NOARGS, NULL},
+    {"set_dataclass_fields_func",
+     (PyCFunction)record_set_dataclass_fields_func, METH_O, NULL},
     {NULL, NULL}
 };
 
@@ -534,6 +546,20 @@ EdgeRecordDesc_List(PyObject *ob, uint8_t include_mask, uint8_t exclude_mask)
     }
 
     return ret;
+}
+
+
+PyObject *
+EdgeRecordDesc_GetDataclassFields(PyObject *ob)
+{
+    if (!EdgeRecordDesc_Check(ob)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+
+    EdgeRecordDescObject *o = (EdgeRecordDescObject *)ob;
+
+    return PyObject_CallNoArgs(o->get_dataclass_fields);
 }
 
 

--- a/edgedb/protocol/codecs/object.pxd
+++ b/edgedb/protocol/codecs/object.pxd
@@ -19,7 +19,9 @@
 
 @cython.final
 cdef class ObjectCodec(BaseNamedRecordCodec):
-    cdef bint is_sparse
+    cdef:
+        bint is_sparse
+        object cached_dataclass_fields
 
     cdef encode_args(self, WriteBuffer buf, dict obj)
 


### PR DESCRIPTION
This would allow using the `EdgeObject` as a dataclass, in particular:

* `dataclasses.is_dataclass(obj)` will return `True`
* `dataclasses.asdict(obj)` will return a proper `dict`
* No impact to performance

Then we could do something like this with FastAPI as an example:

```python
import fastapi
import edgedb
import uuid
from dataclasses import dataclass

app = fastapi.FastAPI()
client = edgedb.create_client()

@dataclass
class Role:
    id: uuid.UUID
    name: str

    @classmethod
    def __get_validators__(cls):
        return []

@dataclass
class User:
    id: uuid.UUID
    name: str
    role: Role

    @classmethod
    def __get_validators__(cls):
        return []

@app.get("/", response_model=User)
def read_root():
    return client.query("select User { name, role: { name } }")[0]
```

Schema:

```
module default {
    type User {
        property name -> str;
        link role -> Role;
    }

    type Role {
        required property name -> str;
    }
}
```