### PR TITLE
[PoC] Codegen

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,6 @@ recursive-include docs *.py *.rst
 recursive-include examples *.py
 recursive-include tests *.py *.pem *.json
 recursive-include edgedb *.pyx *.pxd *.pxi *.py *.c *.h py.typed
+include edgedb/codegen/query.py.template
+include edgedb/codegen/async_query.py.template
 include LICENSE README.rst Makefile

--- a/edgedb/codegen/__init__.py
+++ b/edgedb/codegen/__init__.py
@@ -1,0 +1,17 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/edgedb/codegen/__main__.py
+++ b/edgedb/codegen/__main__.py
@@ -1,0 +1,23 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/edgedb/codegen/async_query.py.template
+++ b/edgedb/codegen/async_query.py.template
@@ -1,10 +1,15 @@
-import edgedb
+from __future__ import annotations
+{gen.imports}import edgedb
 
 
-async def {stem}(client: edgedb.AsyncIOClient, *args, **kwargs):
+{gen.aliases}{gen.definitions}async def {stem}(
+    client: edgedb.AsyncIOClient,
+    *args,
+    **kwargs,
+) -> {out_type}:
     return await client.query(
         """\
-        {content}\
+        {query}\
         """,
         *args,
         **kwargs,

--- a/edgedb/codegen/async_query.py.template
+++ b/edgedb/codegen/async_query.py.template
@@ -1,7 +1,7 @@
 import edgedb
 
 
-async def query(client: edgedb.AsyncIOClient, *args, **kwargs):
+async def {stem}(client: edgedb.AsyncIOClient, *args, **kwargs):
     return await client.query(
         """\
         {content}\

--- a/edgedb/codegen/async_query.py.template
+++ b/edgedb/codegen/async_query.py.template
@@ -1,0 +1,11 @@
+import edgedb
+
+
+async def query(client: edgedb.AsyncIOClient, *args, **kwargs):
+    return await client.query(
+        """\
+        {content}\
+        """,
+        *args,
+        **kwargs,
+    )

--- a/edgedb/codegen/async_query.py.template
+++ b/edgedb/codegen/async_query.py.template
@@ -1,16 +1,12 @@
 from __future__ import annotations
-{gen.imports}import edgedb
+{gen.imports}
 
 
 {gen.aliases}{gen.definitions}async def {stem}(
     client: edgedb.AsyncIOClient,
-    *args,
-    **kwargs,
-) -> {out_type}:
+{in_type_args}){out_type}:
     return await client.query(
         """\
         {query}\
         """,
-        *args,
-        **kwargs,
-    )
+{in_type_call}    )

--- a/edgedb/codegen/binwrapper.py
+++ b/edgedb/codegen/binwrapper.py
@@ -1,0 +1,120 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import io
+import struct
+
+
+class BinWrapper:
+    """A utility binary-reader wrapper over any io.BytesIO object."""
+
+    i64 = struct.Struct('!q')
+    i32 = struct.Struct('!l')
+    i16 = struct.Struct('!h')
+    i8 = struct.Struct('!b')
+
+    ui64 = struct.Struct('!Q')
+    ui32 = struct.Struct('!L')
+    ui16 = struct.Struct('!H')
+    ui8 = struct.Struct('!B')
+
+    def __init__(self, buf: io.BytesIO) -> None:
+        self.buf = buf
+
+    def write_ui64(self, val: int) -> None:
+        self.buf.write(self.ui64.pack(val))
+
+    def write_ui32(self, val: int) -> None:
+        self.buf.write(self.ui32.pack(val))
+
+    def write_ui16(self, val: int) -> None:
+        self.buf.write(self.ui16.pack(val))
+
+    def write_ui8(self, val: int) -> None:
+        self.buf.write(self.ui8.pack(val))
+
+    def write_i64(self, val: int) -> None:
+        self.buf.write(self.i64.pack(val))
+
+    def write_i32(self, val: int) -> None:
+        self.buf.write(self.i32.pack(val))
+
+    def write_i16(self, val: int) -> None:
+        self.buf.write(self.i16.pack(val))
+
+    def write_i8(self, val: int) -> None:
+        self.buf.write(self.i8.pack(val))
+
+    def write_len32_prefixed_bytes(self, val: bytes) -> None:
+        self.write_ui32(len(val))
+        self.buf.write(val)
+
+    def write_bytes(self, val: bytes) -> None:
+        self.buf.write(val)
+
+    def read_ui64(self) -> int:
+        data = self.buf.read(8)
+        return self.ui64.unpack(data)[0]
+
+    def read_ui32(self) -> int:
+        data = self.buf.read(4)
+        return self.ui32.unpack(data)[0]
+
+    def read_ui16(self) -> int:
+        data = self.buf.read(2)
+        return self.ui16.unpack(data)[0]
+
+    def read_ui8(self) -> int:
+        data = self.buf.read(1)
+        return self.ui8.unpack(data)[0]
+
+    def read_i64(self) -> int:
+        data = self.buf.read(8)
+        return self.i64.unpack(data)[0]
+
+    def read_i32(self) -> int:
+        data = self.buf.read(4)
+        return self.i32.unpack(data)[0]
+
+    def read_i16(self) -> int:
+        data = self.buf.read(2)
+        return self.i16.unpack(data)[0]
+
+    def read_i8(self) -> int:
+        data = self.buf.read(1)
+        return self.i8.unpack(data)[0]
+
+    def read_bytes(self, size: int) -> bytes:
+        data = self.buf.read(size)
+        if len(data) != size:
+            raise BufferError(f'cannot read bytes with len={size}')
+        return data
+
+    def read_len32_prefixed_bytes(self) -> bytes:
+        size = self.read_ui32()
+        return self.read_bytes(size)
+
+    def read_nullable_len32_prefixed_bytes(self) -> bytes | None:
+        size = self.read_i32()
+        if size == -1:
+            return None
+        else:
+            return self.read_bytes(size)

--- a/edgedb/codegen/cli.py
+++ b/edgedb/codegen/cli.py
@@ -18,9 +18,40 @@
 
 
 import argparse
+import pathlib
+
+from . import generator
+
+
+parser = argparse.ArgumentParser(
+    description="Generate Python code for .edgeql files."
+)
+parser.add_argument(
+    "file_or_dir",
+    metavar="PATH",
+    nargs="?",
+    type=pathlib.Path,
+    help=(
+        "Path to an .edgeql file, or a directory that contains .edgeql "
+        "files (subdirectories included). Default: current directory"
+    ),
+)
+parser.add_argument(
+    "-f",
+    "--force",
+    action="store_true",
+    help="Force generate all .edgeql files, ignore timestamps",
+)
 
 
 def main():
-    parser = argparse.ArgumentParser()
     args = parser.parse_args()
-    print(args)
+    with generator.Generator(args) as gen:
+        if args.file_or_dir is None:
+            gen.generate_dir(pathlib.Path.cwd())
+        else:
+            file_or_dir = args.file_or_dir.resolve()
+            if file_or_dir.is_dir():
+                gen.generate_dir(file_or_dir)
+            else:
+                gen.generate_file(file_or_dir)

--- a/edgedb/codegen/cli.py
+++ b/edgedb/codegen/cli.py
@@ -52,7 +52,7 @@ parser.add_argument(
 
 def main():
     args = parser.parse_args()
-    with generator.Generator(args) as gen:
+    with generator.DirGenerator(args) as gen:
         if args.file_or_dir is None:
             gen.generate_dir(pathlib.Path.cwd())
         else:

--- a/edgedb/codegen/cli.py
+++ b/edgedb/codegen/cli.py
@@ -37,6 +37,12 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    "--async",
+    dest="asyncio",
+    action="store_true",
+    help="Generate async code instead",
+)
+parser.add_argument(
     "-f",
     "--force",
     action="store_true",

--- a/edgedb/codegen/cli.py
+++ b/edgedb/codegen/cli.py
@@ -1,0 +1,26 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args()
+    print(args)

--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -51,7 +51,7 @@ class Generator:
                 self.generate_file(file_or_dir)
 
     def generate_file(self, source: pathlib.Path):
-        target = source.with_suffix(".py")
+        target = source.with_suffix("_edgeql.py")
         if (
             not self._force
             and target.exists()

--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -19,6 +19,7 @@
 import argparse
 import pathlib
 import sys
+import textwrap
 
 import edgedb
 
@@ -27,6 +28,10 @@ class Generator:
     def __init__(self, args: argparse.Namespace):
         self._force = args.force
         self._client = edgedb.create_client()
+        with pathlib.Path(__file__).with_name(
+            "async_query.py.template" if args.asyncio else "query.py.template"
+        ).open() as f:
+            self._template = f.read()
 
     def __enter__(self):
         self._client.ensure_connected()
@@ -55,6 +60,6 @@ class Generator:
             return
         print(f"Generating {target}", file=sys.stderr)
         with source.open() as f:
-            content = f.read()
+            content = textwrap.indent(f.read().strip(), " " * 8).lstrip()
         with target.open("w") as f:
-            f.write(content)
+            f.write(self._template.format(content=content))

--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -48,10 +48,12 @@ class Generator:
             if file_or_dir.is_dir():
                 self.generate_dir(file_or_dir)
             elif file_or_dir.suffix.lower() == ".edgeql":
-                self.generate_file(file_or_dir)
+                if not file_or_dir.match("dbschema/migrations/*.edgeql"):
+                    self.generate_file(file_or_dir)
 
     def generate_file(self, source: pathlib.Path):
-        target = source.with_suffix("_edgeql.py")
+        stem = source.stem
+        target = source.with_stem(source.stem + "_edgeql").with_suffix(".py")
         if (
             not self._force
             and target.exists()
@@ -62,4 +64,4 @@ class Generator:
         with source.open() as f:
             content = textwrap.indent(f.read().strip(), " " * 8).lstrip()
         with target.open("w") as f:
-            f.write(self._template.format(content=content))
+            f.write(self._template.format(content=content, stem=stem))

--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -1,0 +1,60 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import pathlib
+import sys
+
+import edgedb
+
+
+class Generator:
+    def __init__(self, args: argparse.Namespace):
+        self._force = args.force
+        self._client = edgedb.create_client()
+
+    def __enter__(self):
+        self._client.ensure_connected()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._client.close()
+
+    def generate_dir(self, dir_: pathlib.Path):
+        for file_or_dir in dir_.iterdir():
+            file_or_dir = file_or_dir.resolve()
+            if not file_or_dir.exists():
+                continue
+            if file_or_dir.is_dir():
+                self.generate_dir(file_or_dir)
+            elif file_or_dir.suffix.lower() == ".edgeql":
+                self.generate_file(file_or_dir)
+
+    def generate_file(self, source: pathlib.Path):
+        target = source.with_suffix(".py")
+        if (
+            not self._force
+            and target.exists()
+            and target.stat().st_mtime > source.stat().st_mtime
+        ):
+            return
+        print(f"Generating {target}", file=sys.stderr)
+        with source.open() as f:
+            content = f.read()
+        with target.open("w") as f:
+            f.write(content)

--- a/edgedb/codegen/query.py.template
+++ b/edgedb/codegen/query.py.template
@@ -1,7 +1,7 @@
 import edgedb
 
 
-def query(client: edgedb.Client, *args, **kwargs):
+def {stem}(client: edgedb.Client, *args, **kwargs):
     return client.query(
         """\
         {content}\

--- a/edgedb/codegen/query.py.template
+++ b/edgedb/codegen/query.py.template
@@ -4,13 +4,9 @@ from __future__ import annotations
 
 {gen.aliases}{gen.definitions}def {stem}(
     client: edgedb.Client,
-    *args,
-    **kwargs,
-) -> {out_type}:
+{in_type_args}){out_type}:
     return client.query(
         """\
         {query}\
         """,
-        *args,
-        **kwargs,
-    )
+{in_type_call}    )

--- a/edgedb/codegen/query.py.template
+++ b/edgedb/codegen/query.py.template
@@ -1,0 +1,11 @@
+import edgedb
+
+
+def query(client: edgedb.Client, *args, **kwargs):
+    return client.query(
+        """\
+        {content}\
+        """,
+        *args,
+        **kwargs,
+    )

--- a/edgedb/codegen/query.py.template
+++ b/edgedb/codegen/query.py.template
@@ -1,10 +1,15 @@
-import edgedb
+from __future__ import annotations
+{gen.imports}
 
 
-def {stem}(client: edgedb.Client, *args, **kwargs):
+{gen.aliases}{gen.definitions}def {stem}(
+    client: edgedb.Client,
+    *args,
+    **kwargs,
+) -> {out_type}:
     return client.query(
         """\
-        {content}\
+        {query}\
         """,
         *args,
         **kwargs,

--- a/edgedb/codegen/sertypes.py
+++ b/edgedb/codegen/sertypes.py
@@ -1,0 +1,434 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import io
+import typing
+import uuid
+
+from . import binwrapper
+
+
+CTYPE_SET = b"\x00"
+CTYPE_SHAPE = b"\x01"
+CTYPE_BASE_SCALAR = b"\x02"
+CTYPE_SCALAR = b"\x03"
+CTYPE_TUPLE = b"\x04"
+CTYPE_NAMEDTUPLE = b"\x05"
+CTYPE_ARRAY = b"\x06"
+CTYPE_ENUM = b"\x07"
+CTYPE_INPUT_SHAPE = b"\x08"
+CTYPE_RANGE = b"\x09"
+CTYPE_ANNO_TYPENAME = b"\xff"
+
+
+BASE_SCALAR_TYPES = {
+    uuid.UUID("00000000-0000-0000-0000-000000000100"): "std::uuid",
+    uuid.UUID("00000000-0000-0000-0000-000000000101"): "string",  # std::str
+    uuid.UUID("00000000-0000-0000-0000-000000000102"): "std::bytes",
+    uuid.UUID("00000000-0000-0000-0000-000000000103"): "integer",  # std::int16
+    uuid.UUID("00000000-0000-0000-0000-000000000104"): "integer",  # std::int32
+    uuid.UUID("00000000-0000-0000-0000-000000000105"): "integer",  # std::int64
+    uuid.UUID(
+        "00000000-0000-0000-0000-000000000106"
+    ): "number",  # std::float32
+    uuid.UUID(
+        "00000000-0000-0000-0000-000000000107"
+    ): "number",  # std::float64
+    uuid.UUID("00000000-0000-0000-0000-000000000108"): "std::decimal",
+    uuid.UUID("00000000-0000-0000-0000-000000000109"): "boolean",  # std::bool
+    uuid.UUID("00000000-0000-0000-0000-00000000010a"): "std::datetime",
+    uuid.UUID("00000000-0000-0000-0000-00000000010e"): "std::duration",
+    uuid.UUID("00000000-0000-0000-0000-00000000010f"): "string",  # std::json
+    uuid.UUID(
+        "00000000-0000-0000-0000-000000000110"
+    ): "integer",  # std::bigint
+    uuid.UUID("00000000-0000-0000-0000-00000000010b"): "cal::local_datetime",
+    uuid.UUID("00000000-0000-0000-0000-00000000010c"): "cal::local_date",
+    uuid.UUID("00000000-0000-0000-0000-00000000010d"): "cal::local_time",
+    uuid.UUID(
+        "00000000-0000-0000-0000-000000000111"
+    ): "cal::relative_duration",
+    uuid.UUID("00000000-0000-0000-0000-000000000112"): "cal::date_duration",
+    uuid.UUID("00000000-0000-0000-0000-000000000130"): "cfg::memory",
+}
+
+
+class Cardinality(enum.Enum):
+    # Cardinality isn't applicable for the query:
+    # * the query is a command like CONFIGURE that
+    #   does not return any data;
+    # * the query is composed of multiple queries.
+    NO_RESULT = 0x6E
+
+    # Cardinality is 1 or 0
+    AT_MOST_ONE = 0x6F
+
+    # Cardinality is 1
+    ONE = 0x41
+
+    # Cardinality is >= 0
+    MANY = 0x6D
+
+    # Cardinality is >= 1
+    AT_LEAST_ONE = 0x4D
+
+
+def _parse(
+    desc: binwrapper.BinWrapper,
+    codecs_list: typing.List[TypeDesc],
+) -> typing.Optional[TypeDesc]:
+    t = desc.read_bytes(1)
+    tid = uuid.UUID(bytes=desc.read_bytes(16))
+
+    if t == CTYPE_SET:
+        pos = desc.read_ui16()
+        return SetDesc(tid=tid, subtype=codecs_list[pos])
+
+    elif t == CTYPE_SHAPE or t == CTYPE_INPUT_SHAPE:
+        els = desc.read_ui16()
+        fields = {}
+        flags = {}
+        cardinalities = {}
+        fields_list = []
+        for idx in range(els):
+            flag = desc.read_ui32()
+            cardinality = Cardinality(desc.read_bytes(1)[0])
+            name = desc.read_len32_prefixed_bytes().decode()
+            pos = desc.read_ui16()
+            codec = codecs_list[pos]
+            if t == CTYPE_INPUT_SHAPE:
+                fields_list.append((name, codec))
+                fields[name] = idx, codec
+            else:
+                fields[name] = codec
+            flags[name] = flag
+            if cardinality:
+                cardinalities[name] = cardinality
+        args = dict(
+            tid=tid,
+            flags=flags,
+            fields=fields,
+            cardinalities=cardinalities,
+        )
+        if t == CTYPE_SHAPE:
+            return ShapeDesc(**args)
+        else:
+            return InputShapeDesc(fields_list=fields_list, **args)
+
+    elif t == CTYPE_BASE_SCALAR:
+        return BaseScalarDesc(tid=tid)
+
+    elif t == CTYPE_SCALAR:
+        pos = desc.read_ui16()
+        return ScalarDesc(tid=tid, subtype=codecs_list[pos])
+
+    elif t == CTYPE_TUPLE:
+        els = desc.read_ui16()
+        fields = []
+        for _ in range(els):
+            pos = desc.read_ui16()
+            fields.append(codecs_list[pos])
+        return TupleDesc(tid=tid, fields=fields)
+
+    elif t == CTYPE_NAMEDTUPLE:
+        els = desc.read_ui16()
+        fields = {}
+        for _ in range(els):
+            name = desc.read_len32_prefixed_bytes().decode()
+            pos = desc.read_ui16()
+            fields[name] = codecs_list[pos]
+        return NamedTupleDesc(tid=tid, fields=fields)
+
+    elif t == CTYPE_ENUM:
+        els = desc.read_ui16()
+        names = []
+        for _ in range(els):
+            name = desc.read_len32_prefixed_bytes().decode()
+            names.append(name)
+        return EnumDesc(tid=tid, names=names)
+
+    elif t == CTYPE_ARRAY:
+        pos = desc.read_ui16()
+        els = desc.read_ui16()
+        if els != 1:
+            raise NotImplementedError(
+                "cannot handle arrays with more than one dimension"
+            )
+        dim_len = desc.read_i32()
+        return ArrayDesc(tid=tid, dim_len=dim_len, subtype=codecs_list[pos])
+
+    elif t == CTYPE_RANGE:
+        pos = desc.read_ui16()
+        return RangeDesc(tid=tid, inner=codecs_list[pos])
+
+    elif t[0] >= 0x80 and t[0] <= 0xFF:
+        # Ignore all type annotations.
+        desc.read_len32_prefixed_bytes()
+        return None
+
+    else:
+        raise NotImplementedError(
+            f"no codec implementation for EdgeDB data class {t}"
+        )
+
+
+def parse(typedesc: bytes) -> TypeDesc:
+    buf = io.BytesIO(typedesc)
+    wrapped = binwrapper.BinWrapper(buf)
+    codecs_list = []
+    while buf.tell() < len(typedesc):
+        desc = _parse(wrapped, codecs_list)
+        if desc is not None:
+            codecs_list.append(desc)
+    return codecs_list[-1]
+
+
+def describe(
+    desc: TypeDesc, name: str, cardinality: bytes
+) -> typing.Dict[str, typing.Any]:
+    defs = {}
+    rv = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "definitions": defs,
+    }
+    reg = {}
+    schema = desc.describe(name, defs, reg)
+    cardinality = Cardinality(cardinality[0])
+    if cardinality == Cardinality.MANY:
+        rv.update(
+            {
+                "type": "array",
+                "items": schema,
+            }
+        )
+    else:
+        rv.update(schema)
+    return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class TypeDesc:
+    tid: uuid.UUID
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        raise NotImplementedError
+
+    @staticmethod
+    def find_name(name, defs: typing.Dict[str, typing.Any]):
+        if name in defs:
+            for i in range(64):
+                new_name = f"{name}_{i}"
+                if new_name not in defs:
+                    name = new_name
+                    break
+        return name
+
+
+@dataclasses.dataclass(frozen=True)
+class SetDesc(TypeDesc):
+    subtype: TypeDesc
+    impl: typing.ClassVar[type] = frozenset
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        return {
+            "type": "array",
+            "items": self.subtype.describe(name, defs, reg),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class ShapeDesc(TypeDesc):
+    fields: typing.Dict[str, TypeDesc]
+    flags: typing.Dict[str, int]
+    cardinalities: typing.Dict[str, Cardinality]
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        props = {}
+        defs[name] = {
+            "type": "object",
+            "properties": props,
+        }
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        for name, desc in self.fields.items():
+            if self.cardinalities[name] == Cardinality.MANY:
+                props[name] = {
+                    "type": "array",
+                    "items": desc.describe(name, defs, reg),
+                }
+            else:
+                props[name] = desc.describe(name, defs, reg)
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class ScalarDesc(TypeDesc):
+    subtype: TypeDesc
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        defs[name] = self.subtype.describe(name, defs, reg)
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class BaseScalarDesc(TypeDesc):
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        return {"type": BASE_SCALAR_TYPES[self.tid]}
+
+
+@dataclasses.dataclass(frozen=True)
+class NamedTupleDesc(TypeDesc):
+    fields: typing.Dict[str, TypeDesc]
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        props = {}
+        defs[name] = {
+            "type": "object",
+            "properties": props,
+        }
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        for name, desc in self.fields.items():
+            props[name] = desc.describe(name, defs, reg)
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class TupleDesc(TypeDesc):
+    fields: typing.List[TypeDesc]
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        props = {}
+        defs[name] = {
+            "type": "object",
+            "properties": props,
+        }
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        for i, desc in enumerate(self.fields):
+            props[f"v{i}"] = desc.describe(f"{name}{i}", defs, reg)
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class EnumDesc(TypeDesc):
+    names: typing.List[str]
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        defs[name] = {
+            "type": "string",
+            "enum": self.names,
+        }
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class ArrayDesc(SetDesc):
+    dim_len: int
+    impl: typing.ClassVar[type] = list
+
+
+@dataclasses.dataclass(frozen=True)
+class RangeDesc(TypeDesc):
+    inner: TypeDesc
+
+    def describe(
+        self,
+        name: str,
+        defs: typing.Dict[str, typing.Any],
+        reg: typing.Dict[uuid.UUID, typing.Dict[str, typing.Any]],
+    ) -> typing.Dict[str, typing.Any]:
+        if self.tid in reg:
+            return reg[self.tid]
+        name = self.find_name(name, defs)
+        reg[self.tid] = rv = {"$ref": f"#/definitions/{name}"}
+        defs[name] = {
+            "type": "object",
+            "properties": {
+                "inc_lower": {"type": "boolean"},
+                "inc_upper": {"type": "boolean"},
+                "lower": self.inner.describe(f"{name}_in", defs, reg),
+                "upper": self.inner.describe(f"{name}_in", defs, reg),
+            },
+        }
+        return rv
+
+
+@dataclasses.dataclass(frozen=True)
+class InputShapeDesc(ShapeDesc):
+    fields: typing.Dict[str, typing.Tuple[int, TypeDesc]]
+    fields_list: typing.List[typing.Tuple[str, TypeDesc]]

--- a/setup.py
+++ b/setup.py
@@ -345,4 +345,9 @@ setuptools.setup(
     ],
     extras_require=EXTRA_DEPENDENCIES,
     setup_requires=setup_requires,
+    entry_points={
+        "console_scripts": [
+            "edgedb-py=edgedb.codegen.cli:main",
+        ]
+    }
 )


### PR DESCRIPTION
Put `*.edgeql` files under project directory, and run:

```
python -m edgedb.codegen
```

Generated code would require #359 to run properly in FastAPI.


This PR generates JSON Schema from `Parse` response as an intermediate result, using codec instructs copied from the EdgeDB server, so that we could easily migrate to a future codegen frontend. The JSON Schema looks like this (example from #359):

```json
{"$schema": "https://json-schema.org/draft/2020-12/schema",
 "definitions": {"role": {"properties": {"id": {"type": "std::uuid"},
                                         "name": {"type": "string"}},
                          "type": "object"},
                 "user": {"properties": {"id": {"type": "std::uuid"},
                                         "name": {"type": "string"},
                                         "role": {"$ref": "#/definitions/role"}},
                          "type": "object"}},
 "properties": {"input": {"type": "null"},
                "output": {"items": {"$ref": "#/definitions/user"},
                           "type": "array"}},
 "type": "object"}
```