### PR TITLE
Tweak wording in query_single() error messages

### DIFF
--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -1255,7 +1255,7 @@ cdef class SansIOProtocol:
             methname = _QUERY_SINGLE_METHOD[required_one][output_format]
             new_exc = errors.InterfaceError(
                 f'query cannot be executed with {methname}() as it '
-                f'returns a multiset')
+                f'may return more than one element')
             new_exc.__cause__ = exc
             exc = new_exc
 

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -241,12 +241,14 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'query_single\(\) as it returns a multiset'):
+                    r'query_single\(\) as it may return more than one element'
+            ):
                 await self.client.query_single('SELECT {1, 2}')
 
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'query_required_single\(\) as it returns a multiset'):
+                    r'query_required_single\(\) as it may return '
+                    r'more than one element'):
                 await self.client.query_required_single('SELECT {1, 2}')
 
             with self.assertRaisesRegex(


### PR DESCRIPTION
There is a potential confusion between being a "multi set" (a set with
multi cardinality) and a "multiset" (a set that can contain
duplicates). Reword to avoid this.