### PR TITLE
Officially drop 3.6 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        cibw_python: ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
         cibw_arch: ["auto64"]
-        exclude:
-            # Tests fail on this combination.
-            - os: macos-latest
-              cibw_python: "cp36-*"
 
     defaults:
       run:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The Python driver for EdgeDB
 **edgedb-python** is the official EdgeDB driver for Python.
 It provides both blocking IO and asyncio implementations.
 
-The library requires Python 3.6 or later.
+The library requires Python 3.7 or later.
 
 
 Documentation

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,8 @@
 
 import sys
 
-if sys.version_info < (3, 6):
-    # edgedb.NamedTuple() relies on ordered **kwargs.
-    raise RuntimeError('edgedb requires Python 3.6 or greater')
+if sys.version_info < (3, 7):
+    raise RuntimeError('edgedb requires Python 3.7 or greater')
 
 import os
 import os.path


### PR DESCRIPTION
We depend on dataclasses, which are from 3.7. 3.6 EOLed last year so
hopefully no great loss.