### PR TITLE
Deprecate object links and simplify link property access

### DIFF
--- a/edgedb/datatypes/datatypes.pxd
+++ b/edgedb/datatypes/datatypes.pxd
@@ -67,3 +67,5 @@ cdef namedtuple_new(object namedtuple_type)
 cdef namedtuple_type_new(object desc)
 cdef object_new(object desc)
 cdef object_set(object tuple, Py_ssize_t pos, object elem)
+
+cdef extern cpython.PyObject* at_sign_ptr

--- a/edgedb/datatypes/datatypes.pyx
+++ b/edgedb/datatypes/datatypes.pyx
@@ -35,6 +35,8 @@ Array = list
 Link = EdgeLink_InitType()
 LinkSet = EdgeLinkSet_InitType()
 
+cdef str at_sign = "@"
+at_sign_ptr = <cpython.PyObject*>at_sign
 
 _EDGE_POINTER_IS_IMPLICIT = EDGE_POINTER_IS_IMPLICIT
 _EDGE_POINTER_IS_LINKPROP = EDGE_POINTER_IS_LINKPROP

--- a/tests/datatypes/test_datatypes.py
+++ b/tests/datatypes/test_datatypes.py
@@ -712,9 +712,14 @@ class TestObject(unittest.TestCase):
 
         self.assertEqual(o2s[0]['@lb'], 'linkprop o2 1')
         self.assertEqual(o2s[1]['@lb'], 'linkprop o2 2')
+        self.assertEqual(getattr(o2s[0], '@lb'), 'linkprop o2 1')
+        self.assertEqual(getattr(o2s[1], '@lb'), 'linkprop o2 2')
 
         with self.assertRaises(AttributeError):
             o2s[0].lb
+
+        with self.assertRaises(AttributeError):
+            getattr(o2s[0], "@lb2")
 
         with self.assertRaisesRegex(
             TypeError,
@@ -728,7 +733,7 @@ class TestObject(unittest.TestCase):
             o2s[0]['c']
 
         with self.assertRaisesRegex(
-            KeyError, "link property 'c' does not exist"
+            KeyError, "link property '@c' does not exist"
         ):
             o2s[0]['@c']
 


### PR DESCRIPTION
Accessing `edgedb.Link` or `edgedb.LinkSet` on `edgedb.Object` instances through `__getitem__()` will now raise a `DeprecationWarning`. Accessing link properties through links will be dropped in a future version. Instead, link properties can be accessed now through `edgedb.Object.__getitem__(linked_obj, '@link_prop_name')`, or in short, `linked_obj['@link_prop_name']`.