### PR TITLE
edgedb-python 1.0.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '1.0.0b1'
+__version__ = '1.0.0'


### PR DESCRIPTION
Changes
=======

* Implement dataclass for EdgeObject (#359) (by @fantix in dfb8c8b0 for #359)

* Redo edgedb basic types to inherit from builtin types (#366) (by @fantix in b11b9917 for #366)

* Officially drop 3.6 support (#373) (by @msullivan in 7b76bc73 for #373)

* Support Python 3.11 (#375) (by @msullivan in 04b0da2a for #375)

* Codegen with the describe_query() API (#363) (by @fantix in 361221df for #363)

* Add codegen docs (#380) (by @colinhacks in 23dd42e6 for #380)

* Use typing_extension.Literal in codegen for Python 3.7 (by @fantix in 6d0d6abc)

* Add __all__ to edgedb/__init__.py (by @fmoor in d3ef6d93)

Fixes
=====

* Improve duration parsing (by @fmoor in 241c80d8)

* Tweak wording in query_single() error messages (#369) (by @msullivan in e24bb538 for #369)

* Fix flake tests on python3.7 (#371) (by @msullivan in 583e1cbd for #371)

* Don't reject tuple arguments on the client side (#370) (by @msullivan in 09c950fd for #370)

* Correct edgedb.Client.close() timeout behavior (by @fantix in 33a912c1)

* Ping first if conn is idle for too long (#365) (by @fantix in 99cf78a0 for #365)

* Use @-prefixed keys in object codec for link properties (#384) (by @fantix in 68480f92 for #377)

Deprecations
============

* Deprecate object links and simplify link property access (#379) (by @fantix in 2c5dcc70 for #379)