### PR TITLE
add atomic iteration option to codegen

### DIFF
--- a/edgedb/codegen/cli.py
+++ b/edgedb/codegen/cli.py
@@ -52,6 +52,11 @@ parser.add_argument(
     default=["async"],
     help="Choose one or more targets to generate code (default is async)."
 )
+parser.add_argument(
+    "--atomic",
+    action="store_true",
+    help="Use Iteration Transaction for atomic transactions rather than Client. (default is client)"
+)
 if sys.version_info[:2] >= (3, 9):
     parser.add_argument(
         "--skip-pydantic-validation",


### PR DESCRIPTION
Adds atomic transactions option to change client to transaction iteration.

This and similar for blocking:
```python
if self._atomic:
    print(f"{INDENT}transaction: edgedb.asyncio_client.AsyncIOIteration,", file=buf)
else:
    print(f"{INDENT}client: edgedb.AsyncIOClient,", file=buf)
```