### PR TITLE
Handle ErrorResponse in ping

### DIFF
--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -153,7 +153,7 @@ class BlockingIOConnection(base_client.BaseConnection):
                 > self._ping_wait_time
             ):
                 await self._protocol.ping()
-        except errors.ClientConnectionError:
+        except (errors.IdleSessionTimeoutError, errors.ClientConnectionError):
             await self.connect()
 
         return await super().raw_query(query_context)

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -152,7 +152,7 @@ class BlockingIOConnection(base_client.BaseConnection):
                 time.monotonic() - self._protocol.last_active_timestamp
                 > self._ping_wait_time
             ):
-                await self._protocol._sync()
+                await self._protocol.ping()
         except errors.ClientConnectionError:
             await self.connect()
 


### PR DESCRIPTION
This improves the error output when an `ErrorResponse` is received upon `Sync` after the client connection is idle over `_ping_wait_time`. The error was:

```pycon
Traceback (most recent call last):
  File "edgedb/blocking_client.py", line 155, in raw_query
    await self._protocol._sync()
  File "edgedb/protocol/protocol.pyx", line 712, in _sync
  File "edgedb/protocol/protocol.pyx", line 1071, in edgedb.protocol.protocol.SansIOProtocol.fallthrough
edgedb.errors.ProtocolError: unexpected message type 'E'
```

~But this cannot explain or fix the server issue why an `ErrorResponse` is returned upon `Sync`.~

The server will send an `IdleSessionTimeoutError` when killing idle connections:

https://github.com/edgedb/edgedb/blob/2b426dccf6f2c4af60915a8ee47a41eff1f6a00c/edb/server/protocol/binary.pyx#L371-L378

Depending on the idle time (comparing to socket write timeout), the blocking client may still receive this error on `ping`. In this case, we should just reconnect and recover.

Refs #365 