### PR TITLE
Output pretty error if possible

### DIFF
--- a/edgedb/color.py
+++ b/edgedb/color.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import warnings
+
+COLOR = None
+
+
+class Color:
+    HEADER = ""
+    BLUE = ""
+    CYAN = ""
+    GREEN = ""
+    WARNING = ""
+    FAIL = ""
+    ENDC = ""
+    BOLD = ""
+    UNDERLINE = ""
+
+
+def get_color() -> Color:
+    global COLOR
+
+    if COLOR is None:
+        COLOR = Color()
+        if type(USE_COLOR) is bool:
+            use_color = USE_COLOR
+        else:
+            try:
+                use_color = USE_COLOR()
+            except Exception:
+                use_color = False
+        if use_color:
+            COLOR.HEADER = '\033[95m'
+            COLOR.BLUE = '\033[94m'
+            COLOR.CYAN = '\033[96m'
+            COLOR.GREEN = '\033[92m'
+            COLOR.WARNING = '\033[93m'
+            COLOR.FAIL = '\033[91m'
+            COLOR.ENDC = '\033[0m'
+            COLOR.BOLD = '\033[1m'
+            COLOR.UNDERLINE = '\033[4m'
+
+    return COLOR
+
+
+try:
+    USE_COLOR = {
+        "default": lambda: sys.stderr.isatty(),
+        "auto": lambda: sys.stderr.isatty(),
+        "enabled": True,
+        "disabled": False,
+    }[
+        os.getenv("EDGEDB_COLOR_OUTPUT", "default")
+    ]
+except KeyError:
+    warnings.warn(
+        "EDGEDB_COLOR_OUTPUT can only be one of: "
+        "default, auto, enabled or disabled"
+    )
+    USE_COLOR = False

--- a/edgedb/errors/_base.py
+++ b/edgedb/errors/_base.py
@@ -213,14 +213,14 @@ def _severity_name(severity):
 
 def _format_error(msg, query, start, offset, line, col, hint):
     rv = io.StringIO()
-    rv.write(f"{BOLD}{msg}{ENDC}\n")
+    rv.write(f"{BOLD}{msg}{ENDC}{LINESEP}")
     lines = query.splitlines(keepends=True)
     num_len = len(str(len(lines)))
-    rv.write(f"{OKBLUE}{'':>{num_len}} ┌─{ENDC} query:{line}:{col}\n")
-    rv.write(f"{OKBLUE}{'':>{num_len}} │ {ENDC} \n")
+    rv.write(f"{OKBLUE}{'':>{num_len}} ┌─{ENDC} query:{line}:{col}{LINESEP}")
+    rv.write(f"{OKBLUE}{'':>{num_len}} │ {ENDC}{LINESEP}")
     for num, line in enumerate(lines):
         length = len(line)
-        line = line.rstrip()  # we'll use our own newline
+        line = line.rstrip()  # we'll use our own line separator
         if start >= length:
             # skip lines before the error
             start -= length
@@ -240,18 +240,18 @@ def _format_error(msg, query, start, offset, line, col, hint):
         if offset > length:
             # Error is ending beyond current line
             line = repr(line)[1:-1]
-            rv.write(f"{FAIL}{line}{ENDC}\n")
+            rv.write(f"{FAIL}{line}{ENDC}{LINESEP}")
             if start >= 0:
                 # Multi-line error starts
                 rv.write(f"{OKBLUE}{'':>{num_len}} │ "
-                         f"{FAIL}╭─{'─' * start}^{ENDC} \n")
+                         f"{FAIL}╭─{'─' * start}^{ENDC}{LINESEP}")
             offset -= length
             start = -1  # mark multi-line
         else:
             # Error is ending within current line
             first_half = repr(line[:offset])[1:-1]
             line = repr(line[offset:])[1:-1]
-            rv.write(f"{FAIL}{first_half}{ENDC}{line}\n")
+            rv.write(f"{FAIL}{first_half}{ENDC}{line}{LINESEP}")
             size = _unicode_width(first_half)
             if start >= 0:
                 # Mark single-line error
@@ -313,3 +313,4 @@ if os.getenv(
 else:
     HEADER = OKBLUE = OKCYAN = OKGREEN = WARNING = ""
     FAIL = ENDC = BOLD = UNDERLINE = ""
+LINESEP = os.linesep

--- a/edgedb/errors/_base.py
+++ b/edgedb/errors/_base.py
@@ -145,7 +145,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def __str__(self):
         msg = super().__str__()
-        if self._query and self._position_start >= 0:
+        if SHOW_HINT and self._query and self._position_start >= 0:
             return _format_error(
                 msg,
                 self._query,
@@ -281,8 +281,8 @@ def _init_colors():
     COLOR_INITIALIZED = True
     try:
         use_color = os.getenv(
-            "EDGEDB_PRETTY_ERROR", "1" if sys.stderr.isatty() else "0"
-        ).lower() in {"1", "yes", "y", "true", "t", "on"}
+            "EDGEDB_PRETTY_ERROR", str(sys.stderr.isatty())
+        ).lower() in ENV_ON_FLAGS
     except Exception:
         use_color = False
     if use_color:
@@ -327,4 +327,6 @@ EDGE_SEVERITY_PANIC = 255
 
 
 LINESEP = os.linesep
+ENV_ON_FLAGS = {"1", "yes", "y", "true", "t", "on"}
+SHOW_HINT = os.getenv("EDGEDB_ERROR_HINT", "1").lower() in ENV_ON_FLAGS
 COLOR_INITIALIZED = False

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -305,6 +305,7 @@ cdef class SansIOProtocol:
 
                 elif mtype == ERROR_RESPONSE_MSG:
                     exc = self.parse_error_message()
+                    exc._query = query
                     exc = self._amend_parse_error(
                         exc, output_format, expect_one, required_one)
 
@@ -435,6 +436,7 @@ cdef class SansIOProtocol:
 
                 elif mtype == ERROR_RESPONSE_MSG:
                     exc = self.parse_error_message()
+                    exc._query = query
                     if exc.get_code() == parameter_type_mismatch_code:
                         if not isinstance(in_dc, NullCodec):
                             buf = WriteBuffer.new()


### PR DESCRIPTION
Error position and hint are now by default included if present (managed by `EDGEDB_ERROR_HINT`), colored if the stderr refers to a terminal, overridden by `EDGEDB_PRETTY_ERROR`.

Fixes #395 

```python
c.query("select $0")
```

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1751601/202483799-385da126-99b0-402a-8b49-15040851dd96.png">

```python
c.query("select ('\033[95m嘿嘿嘿', 1 < '\033[95m哈哈😁lol');")
```

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1751601/202482914-0fe84432-aa20-4c0e-8537-5c614d723357.png">

```python
c.query("""\
select (
    '\033[95m哈哈哈哈哈哈哈😁', '\033[95m嘿嘿嘿' < (
        2, 3, 4,
    ), 345
);
""")
```

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1751601/202482795-df794ab9-df20-4402-8b7a-6a32f390ffb1.png">
