### PR TITLE
Fix state of transaction start

### DIFF
--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -186,6 +186,10 @@ class BaseConnection(metaclass=abc.ABCMeta):
                 qc=execute_context.cache.query_cache,
                 output_format=protocol.OutputFormat.NONE,
                 allow_capabilities=enums.Capability.ALL,
+                state=(
+                    execute_context.state.as_dict()
+                    if execute_context.state else None
+                ),
             )
 
     def is_in_transaction(self) -> bool:

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -868,3 +868,18 @@ class TestSyncQuery(tb.SyncQueryTestCase):
             r'cannot execute transaction control commands',
         ):
             self.client.execute('start transaction')
+
+    def test_transaction_state(self):
+        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to id"):
+            for tx in self.client.transaction():
+                with tx:
+                    tx.execute('''
+                        INSERT test::Tmp { id := <uuid>$0, tmp := '' }
+                    ''', uuid.uuid4())
+
+        client = self.client.with_config(allow_user_specified_id=True)
+        for tx in client.transaction():
+            with tx:
+                tx.execute('''
+                    INSERT test::Tmp { id := <uuid>$0, tmp := '' }
+                ''', uuid.uuid4())


### PR DESCRIPTION
This affects the case when compilation config is set on the client, while a new command is compiled within a transaction. In this case, the compiler will only use the state issued in the transaction start. Before this fix, we didn't send state on transaction commands, so those config was not in effect within transactions, even though each query did carry the right config.