### PR TITLE
Fix enum values

### DIFF
--- a/edgedb/datatypes/enum.pyx
+++ b/edgedb/datatypes/enum.pyx
@@ -27,33 +27,42 @@ class EnumValue(enum.Enum):
     def __repr__(self):
         return f'<edgedb.EnumValue {self._value_!r}>'
 
+    @classmethod
+    def _try_from(cls, value):
+        if isinstance(value, EnumValue):
+            return value
+        elif isinstance(value, enum.Enum):
+            return cls(value.value)
+        else:
+            raise TypeError
+
     def __lt__(self, other):
-        if not isinstance(other, EnumValue):
-            return NotImplemented
+        other = self._try_from(other)
         if self.__tid__ != other.__tid__:
             return NotImplemented
         return self._index_ < other._index_
 
     def __gt__(self, other):
-        if not isinstance(other, EnumValue):
-            return NotImplemented
+        other = self._try_from(other)
         if self.__tid__ != other.__tid__:
             return NotImplemented
         return self._index_ > other._index_
 
     def __le__(self, other):
-        if not isinstance(other, EnumValue):
-            return NotImplemented
+        other = self._try_from(other)
         if self.__tid__ != other.__tid__:
             return NotImplemented
         return self._index_ <= other._index_
 
     def __ge__(self, other):
-        if not isinstance(other, EnumValue):
-            return NotImplemented
+        other = self._try_from(other)
         if self.__tid__ != other.__tid__:
             return NotImplemented
         return self._index_ >= other._index_
 
+    def __eq__(self, other):
+        other = self._try_from(other)
+        return self is other
+
     def __hash__(self):
-        return hash((self.__tid__, self._value_))
+        return hash(self._value_)

--- a/edgedb/protocol/codecs/enum.pyx
+++ b/edgedb/protocol/codecs/enum.pyx
@@ -24,9 +24,13 @@ cdef class EnumCodec(BaseCodec):
 
     cdef encode(self, WriteBuffer buf, object obj):
         if not isinstance(obj, (self.cls, str)):
-            raise TypeError(
-                f'a str or edgedb.EnumValue(__tid__={self.cls.__tid__}) is '
-                f'expected as a valid enum argument, got {type(obj).__name__}')
+            try:
+                obj = self.cls._try_from(obj)
+            except (TypeError, ValueError):
+                raise TypeError(
+                    f'a str or edgedb.EnumValue(__tid__={self.cls.__tid__}) '
+                    f'is expected as a valid enum argument, '
+                    f'got {type(obj).__name__}') from None
         pgproto.text_encode(DEFAULT_CODEC_CONTEXT, buf, str(obj))
 
     cdef decode(self, FRBuffer *buf):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -43,8 +43,10 @@ class TestEnum(tb.AsyncQueryTestCase):
         self.assertEqual(repr(ct_red), "<edgedb.EnumValue 'red'>")
 
         self.assertEqual(str(ct_red), 'red')
-        self.assertNotEqual(ct_red, 'red')
-        self.assertFalse(ct_red == 'red')
+        with self.assertRaises(TypeError):
+            _ = ct_red != 'red'
+        with self.assertRaises(TypeError):
+            _ = ct_red == 'red'
         self.assertFalse(ct_red == c_red)
 
         self.assertEqual(ct_red, ct_red)
@@ -74,8 +76,8 @@ class TestEnum(tb.AsyncQueryTestCase):
         with self.assertRaises(TypeError):
             _ = ct_red >= c_red
 
-        self.assertNotEqual(hash(ct_red), hash(c_red))
-        self.assertNotEqual(hash(ct_red), hash('red'))
+        self.assertEqual(hash(ct_red), hash(c_red))
+        self.assertEqual(hash(ct_red), hash('red'))
 
     async def test_enum_02(self):
         c_red = await self.client.query_single('SELECT <Color>"red"')


### PR DESCRIPTION
User-defined enums can be used interchangably with edgedb.EnumValue, like the `__eq__` (`==`) test, `__hash__` (as dict key) or comparing will pass between user enum and edgedb.EnumValue, but the `is` check won't pass.

This fixes a typing issue in the codegen. Fixes #419