### PR TITLE
Don't depend on exact syntax errors in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         edgedb-version: [stable , nightly]

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -62,16 +62,10 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
             with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 await self.client.query('select syntax error')
 
-            with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError,
-                r"(Unexpected end of line)|(Missing '\)')"
-            ):
+            with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 await self.client.query('select (')
 
-            with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError,
-                r"(Unexpected end of line)|(Missing '\)')"
-            ):
+            with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 await self.client.query_json('select (')
 
             for _ in range(10):

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -849,7 +849,7 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
 
                         g.create_task(exec_to_fail())
 
-                        await asyncio.wait_for(fut, 1)
+                        await asyncio.wait_for(fut, 5)
                         await asyncio.sleep(0.1)
 
                         with self.assertRaises(asyncio.TimeoutError):

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -53,16 +53,10 @@ class TestSyncQuery(tb.SyncQueryTestCase):
             with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 self.client.query('select syntax error')
 
-            with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError,
-                r"(Unexpected end of line)|(Missing '\)')"
-            ):
+            with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 self.client.query('select (')
 
-            with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError,
-                r"(Unexpected end of line)|(Missing '\)')"
-            ):
+            with self.assertRaises(edgedb.EdgeQLSyntaxError):
                 self.client.query_json('select (')
 
             for _ in range(10):


### PR DESCRIPTION
We have tests for syntax errors in the server, we're just testing the
binding/protocol flow here. (And other places test that messages come
through more generally.)