### PR TITLE
Allow specifying expect_one in _describe_query()

### DIFF
--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -78,6 +78,7 @@ class DescribeContext:
     state: typing.Optional[options.State]
     inject_type_names: bool
     output_format: protocol.OutputFormat
+    expect_one: bool
 
 
 @dataclasses.dataclass

--- a/edgedb/asyncio_client.py
+++ b/edgedb/asyncio_client.py
@@ -388,12 +388,14 @@ class AsyncIOClient(base_client.BaseClient, abstract.AsyncIOExecutor):
         *,
         inject_type_names: bool = False,
         output_format: OutputFormat = OutputFormat.BINARY,
+        expect_one: bool = False,
     ) -> abstract.DescribeResult:
         return await self._describe(abstract.DescribeContext(
             query=query,
             state=self._get_state(),
             inject_type_names=inject_type_names,
             output_format=output_format,
+            expect_one=expect_one,
         ))
 
 

--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -298,6 +298,8 @@ class BaseConnection(metaclass=abc.ABCMeta):
             reg=protocol.CodecsRegistry(),
             inline_typenames=describe_context.inject_type_names,
             output_format=describe_context.output_format,
+            expect_one=describe_context.expect_one,
+            allow_capabilities=enums.Capability.EXECUTE,
             state=(
                 describe_context.state.as_dict()
                 if describe_context.state else None

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -402,12 +402,14 @@ class Client(base_client.BaseClient, abstract.Executor):
         *,
         inject_type_names: bool = False,
         output_format: OutputFormat = OutputFormat.BINARY,
+        expect_one: bool = False,
     ) -> abstract.DescribeResult:
         return self._iter_coroutine(self._describe(abstract.DescribeContext(
             query=query,
             state=self._get_state(),
             inject_type_names=inject_type_names,
             output_format=output_format,
+            expect_one=expect_one,
         )))
 
 


### PR DESCRIPTION
This also sets allow_capabilities to EXECUTE to be the same as in query/execute.