### PR TITLE
edgedb-python 1.7.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '1.6.0'
+__version__ = '1.7.0'


### PR DESCRIPTION
Changes
=======

* Add an fts::language type that is encoded as text (#417)
  (by @msullivan in 9e7d2d24 for #417)

* Drop support of Python 3.7 (#435)
  (by @fantix in 758a3919 for #435)

Fixes
=====

* Fix codegen for pgvector (#447)
  (by @fantix in 7aa58bdd for #446)

* Use name hint when server is not providing custom scalar type name (#461)
  (by @arunaruljothi in 6c6225ec for #457)