### PR TITLE
Fix test that broke due to error message change

### DIFF
--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1136,7 +1136,7 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
         ''')
 
     async def test_transaction_state(self):
-        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to id"):
+        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to.*id"):
             async for tx in self.client.transaction():
                 async with tx:
                     await tx.execute('''

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -868,7 +868,7 @@ class TestSyncQuery(tb.SyncQueryTestCase):
             self.client.execute('start transaction')
 
     def test_transaction_state(self):
-        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to id"):
+        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to.*id"):
             for tx in self.client.transaction():
                 with tx:
                     tx.execute('''


### PR DESCRIPTION
Some error messages were changed in #6209.  When I first saw this
failing, I was very worried that it was a state bug introduced by