### PR TITLE
Fix for Pydantic 2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,9 +88,6 @@ jobs:
         LOOP_IMPL: ${{ matrix.loop }}
         SERVER_VERSION: ${{ matrix.edgedb-version }}
       run: |
-        if [ "${SERVER_VERSION}" = "nightly" ]; then
-          export EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX=.assert4
-        fi
         if [ "${LOOP_IMPL}" = "uvloop" ]; then
             env USE_UVLOOP=1 python -m unittest -v tests.suite
         else

--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -98,7 +98,14 @@ INPUT_TYPE_IMPORTS.update(
 PYDANTIC_MIXIN = """\
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project1/select_optional_json_async_edgeql.py.assert
+++ b/tests/codegen/test-project1/select_optional_json_async_edgeql.py.assert
@@ -11,7 +11,14 @@ import uuid
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project2/object/link_prop_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/object/link_prop_async_edgeql.py.assert
@@ -12,7 +12,14 @@ import uuid
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project2/object/select_object_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/object/select_object_async_edgeql.py.assert
@@ -11,7 +11,14 @@ import uuid
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project2/object/select_objects_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/object/select_objects_async_edgeql.py.assert
@@ -11,7 +11,14 @@ import uuid
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project2/parpkg/select_args_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/parpkg/select_args_async_edgeql.py.assert
@@ -11,7 +11,14 @@ import uuid
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/codegen/test-project2/parpkg/subpkg/my_query_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/parpkg/subpkg/my_query_async_edgeql.py.assert
@@ -17,7 +17,14 @@ MyScalar = int
 
 class NoPydanticValidation:
     @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        # Pydantic 2.x
+        from pydantic_core.core_schema import any_schema
+        return any_schema()
+
+    @classmethod
     def __get_validators__(cls):
+        # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
         pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -27,7 +27,8 @@ import tempfile
 from edgedb import _testbase as tb
 
 
-ASSERT_SUFFIX = os.environ.get("EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX", ".assert")
+# Use ".assert" for EdgeDB 3.x and lower
+ASSERT_SUFFIX = os.environ.get("EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX", ".assert4")
 
 
 class TestCodegen(tb.AsyncQueryTestCase):


### PR DESCRIPTION
Background:

* Pydantic v2 has a limitation (pydantic/pydantic#7111) that `TypeAdapter` needs to look back in the stack for typing context (e.g. in globals). Therefore, FastAPI cannot currently use non-Pydantic types with forward type references properly.
* Pydantic v2 changed the internal API and deprecated `__get_validators__()` in favor of the new schema design.

Solution:

Skip constructing `dataclass` schema under Pydantic v2 through `__get_pydantic_core_schema__()`, which:

1. Avoids looking into the model types at all, unblocking FastAPI with Pydantic v2;
2. Skips Pydantic validation;
3. Is preferred over the `__get_validators__()`, so the latter can stay for v1 compatibility.

Fixes #466