### PR TITLE
edgedb-python 1.8.0

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '1.7.0'
+__version__ = '1.8.0'


### PR DESCRIPTION
Fixes
=====

* Fix test that broke due to error message change (#465)
  (by @msullivan in fed7b247 for #465)

* Don't fail if 'id' is missing from an object. (#464)
  (by @msullivan in be2de715 for #464)

* docs: Fix typos is docs (#467)
  (by @elliotwaite in b4d91b9c for #467)

* Fix for Pydantic 2.x (#468)
  (by @fantix in c6581cbd for #468)