### PR TITLE
Add handling of `branch` option.

### DIFF
--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -118,6 +118,10 @@ class BaseConnection(metaclass=abc.ABCMeta):
     def dbname(self) -> str:
         return self._params.database
 
+    @property
+    def branch(self) -> str:
+        return self._params.branch
+
     @abc.abstractmethod
     def is_closed(self) -> bool:
         ...
@@ -679,6 +683,7 @@ class BaseClient(abstract.BaseReadOnlyExecutor, _options._OptionsMixin):
         password: str = None,
         secret_key: str = None,
         database: str = None,
+        branch: str = None,
         tls_ca: str = None,
         tls_ca_file: str = None,
         tls_security: str = None,
@@ -697,6 +702,7 @@ class BaseClient(abstract.BaseReadOnlyExecutor, _options._OptionsMixin):
             "password": password,
             "secret_key": secret_key,
             "database": database,
+            "branch": branch,
             "timeout": timeout,
             "tls_ca": tls_ca,
             "tls_ca_file": tls_ca_file,

--- a/edgedb/credentials.py
+++ b/edgedb/credentials.py
@@ -14,7 +14,9 @@ class RequiredCredentials(typing.TypedDict, total=True):
 class Credentials(RequiredCredentials, total=False):
     host: typing.Optional[str]
     password: typing.Optional[str]
+    # Either database or branch may appear in credentials, but not both.
     database: typing.Optional[str]
+    branch: typing.Optional[str]
     tls_ca: typing.Optional[str]
     tls_security: typing.Optional[str]
 
@@ -63,6 +65,15 @@ def validate_credentials(data: dict) -> Credentials:
         if not isinstance(database, str):
             raise ValueError("`database` must be a string")
         result['database'] = database
+
+    branch = data.get('branch')
+    if branch is not None:
+        if not isinstance(branch, str):
+            raise ValueError("`branch` must be a string")
+        if database is not None:
+            raise ValueError(
+                f"`database` and `branch` cannot both be set")
+        result['branch'] = branch
 
     password = data.get('password')
     if password is not None:

--- a/tests/test_con_utils.py
+++ b/tests/test_con_utils.py
@@ -120,6 +120,7 @@ class TestConUtils(unittest.TestCase):
         host = opts.get('host')
         port = opts.get('port')
         database = opts.get('database')
+        branch = opts.get('branch')
         user = opts.get('user')
         password = opts.get('password')
         secret_key = opts.get('secretKey')
@@ -233,6 +234,7 @@ class TestConUtils(unittest.TestCase):
                 credentials=credentials,
                 credentials_file=credentials_file,
                 database=database,
+                branch=branch,
                 user=user,
                 password=password,
                 secret_key=secret_key,
@@ -250,6 +252,7 @@ class TestConUtils(unittest.TestCase):
                     connect_config.address[0], connect_config.address[1]
                 ],
                 'database': connect_config.database,
+                'branch': connect_config.branch,
                 'user': connect_config.user,
                 'password': connect_config.password,
                 'secretKey': connect_config.secret_key,
@@ -289,7 +292,7 @@ class TestConUtils(unittest.TestCase):
                 if key in os.environ:
                     del os.environ[key]
 
-    def test_test_connect_params_run_testcase(self):
+    def test_test_connect_params_run_testcase_01(self):
         with self.environ(EDGEDB_PORT='777'):
             self.run_testcase({
                 'env': {
@@ -301,6 +304,31 @@ class TestConUtils(unittest.TestCase):
                 'result': {
                     'address': ['abc', 5656],
                     'database': 'edgedb',
+                    'branch': '__default__',
+                    'user': '__test__',
+                    'password': None,
+                    'secretKey': None,
+                    'tlsCAData': None,
+                    'tlsSecurity': 'strict',
+                    'serverSettings': {},
+                    'waitUntilAvailable': 30,
+                },
+            })
+
+    def test_test_connect_params_run_testcase_02(self):
+        with self.environ(EDGEDB_PORT='777'):
+            self.run_testcase({
+                'env': {
+                    'EDGEDB_HOST': 'abc'
+                },
+                'opts': {
+                    'user': '__test__',
+                    'branch': 'new_branch',
+                },
+                'result': {
+                    'address': ['abc', 5656],
+                    'database': 'new_branch',
+                    'branch': 'new_branch',
                     'user': '__test__',
                     'password': None,
                     'secretKey': None,
@@ -399,6 +427,7 @@ class TestConUtils(unittest.TestCase):
                         password=None,
                         secret_key=None,
                         database=None,
+                        branch=None,
                         tls_ca=None,
                         tls_ca_file=None,
                         tls_security=None,


### PR DESCRIPTION
The new `branch` option can be used instead of the old `database` option. These are mutually exclusive and will generally produce an error if used at the same time (except when one appears in settings that completely override other sources of options).

The branch option can be passed in the following manner:
- as a kwarg `branch` to the client
- as `EDGEDB_BRANCH` environment variable
- as a `branch` field of the credentials
- as a `branch` query parameter in DSN

This binding will accept either `branch` or `database` option and will normalize the result as `database` when connecting to the EdgeDB server (for compatibility with older servers during the period of deprecation of `database` term).