### PR TITLE
fix ipv6 connection issues

### DIFF
--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -49,7 +49,9 @@ class BlockingIOConnection(base_client.BaseConnection):
             # UNIX socket
             sock = socket.socket(socket.AF_UNIX)
         else:
-            sock = socket.socket(socket.AF_INET)
+            addr_info = socket.getaddrinfo(addr[0], addr[1], type=socket.SOCK_STREAM)[0]
+            addr = addr_info[4]
+            sock = socket.socket(addr_info[0], addr_info[1])
 
         try:
             sock.settimeout(timeout)


### PR DESCRIPTION
Addresses #486

Uses [`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo) to get address family from provided host and port for the blocking client. This addresses the previous issue that only ipv4 clients were allowed.