### PR TITLE
blocking client: fix connect and timeout

### DIFF
--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -47,23 +47,57 @@ class BlockingIOConnection(base_client.BaseConnection):
 
         if isinstance(addr, str):
             # UNIX socket
-            sock = socket.socket(socket.AF_UNIX)
+            res_list = [(socket.AF_UNIX, socket.SOCK_STREAM, -1, None, addr)]
         else:
-            addr_info = socket.getaddrinfo(addr[0], addr[1], type=socket.SOCK_STREAM)[0]
-            addr = addr_info[4]
-            sock = socket.socket(addr_info[0], addr_info[1])
-
-        try:
-            sock.settimeout(timeout)
-
+            host, port = addr
             try:
-                sock.connect(addr)
+                # getaddrinfo() doesn't take timeout!!
+                res_list = socket.getaddrinfo(
+                    host, port, socket.AF_UNSPEC, socket.SOCK_STREAM
+                )
+            except socket.gaierror as e:
+                # All name resolution errors are considered temporary
+                err = errors.ClientConnectionFailedTemporarilyError(str(e))
+                raise err from e
 
-                if not isinstance(addr, str):
-                    time_left = deadline - time.monotonic()
-                    if time_left <= 0:
-                        raise TimeoutError
+        for i, res in enumerate(res_list):
+            af, socktype, proto, _, sa = res
+            try:
+                sock = socket.socket(af, socktype, proto)
+            except OSError as e:
+                sock.close()
+                if i < len(res_list) - 1:
+                    continue
+                else:
+                    raise con_utils.wrap_error(e) from e
+            try:
+                await self._connect_addr(sock, addr, sa, deadline)
+            except TimeoutError:
+                raise
+            except Exception:
+                if i < len(res_list) - 1:
+                    continue
+                else:
+                    raise
+            else:
+                break
 
+    async def _connect_addr(self, sock, addr, sa, deadline):
+        try:
+            time_left = deadline - time.monotonic()
+            if time_left <= 0:
+                raise TimeoutError
+            try:
+                sock.settimeout(time_left)
+                sock.connect(sa)
+            except OSError as e:
+                raise con_utils.wrap_error(e) from e
+
+            if not isinstance(addr, str):
+                time_left = deadline - time.monotonic()
+                if time_left <= 0:
+                    raise TimeoutError
+                try:
                     # Upgrade to TLS
                     sock.settimeout(time_left)
                     try:
@@ -76,12 +110,8 @@ class BlockingIOConnection(base_client.BaseConnection):
                         raise con_utils.wrap_error(e) from e
                     else:
                         con_utils.check_alpn_protocol(sock)
-            except socket.gaierror as e:
-                # All name resolution errors are considered temporary
-                err = errors.ClientConnectionFailedTemporarilyError(str(e))
-                raise err from e
-            except OSError as e:
-                raise con_utils.wrap_error(e) from e
+                except OSError as e:
+                    raise con_utils.wrap_error(e) from e
 
             time_left = deadline - time.monotonic()
             if time_left <= 0:
@@ -94,9 +124,9 @@ class BlockingIOConnection(base_client.BaseConnection):
             proto.set_connection(self)
 
             try:
-                sock.settimeout(time_left)
-                await proto.connect()
-                sock.settimeout(None)
+                await proto.wait_for(proto.connect(), time_left)
+            except TimeoutError:
+                raise
             except OSError as e:
                 raise con_utils.wrap_error(e) from e
 

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -49,7 +49,9 @@ class BlockingIOConnection(base_client.BaseConnection):
             # UNIX socket
             sock = socket.socket(socket.AF_UNIX)
         else:
-            sock = socket.socket(socket.AF_INET)
+            addr_info = socket.getaddrinfo(addr[0], addr[1], type=socket.SOCK_STREAM)[0]
+            addr = addr_info[4]
+            sock = socket.socket(addr_info[0], addr_info[1])
 
         try:
             sock.settimeout(timeout)

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -135,6 +135,9 @@ class BlockingIOConnection(base_client.BaseConnection):
                     await self._protocol.wait_for(
                         self._protocol.wait_for_disconnect(), timeout
                     )
+            except TimeoutError:
+                self.terminate()
+                raise errors.QueryTimeoutError()
             except Exception:
                 self.terminate()
                 raise


### PR DESCRIPTION
* Fix an internal method `BlockingIOProtocol.wait_for()` to always raise `TimeoutError` on timeout for internal use
* New connection will now (always) do name resolution, and try all resolved addresses (including IPv6) until succeed
* The timeout handling in `connect_addr()` is also improved, mostly fixing wrong early wraps of `TimeoutError` (they should be caught and manually handled, re-raising `ClientConnectionTimeoutError` in the outer `BaseConnection.connect()`)

Refs #491 for the initial IPv6 fix, fixes #486