### PR TITLE
Extract ExecuteContext as in/out argument

### DIFF
--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -372,10 +372,16 @@ class ConnectedTestCaseMixin:
         database='edgedb',
         user='edgedb',
         password='test',
+        host=...,
+        port=...,
         connection_class=...,
     ):
         conargs = cls.get_connect_args(
             cluster=cluster, database=database, user=user, password=password)
+        if host is not ...:
+            conargs['host'] = host
+        if port is not ...:
+            conargs['port'] = port
         if connection_class is ...:
             connection_class = (
                 asyncio_client.AsyncIOConnection

--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -65,11 +65,41 @@ class QueryContext(typing.NamedTuple):
     retry_options: typing.Optional[options.RetryOptions]
     state: typing.Optional[options.State]
 
+    def lower(
+        self, *, allow_capabilities: enums.Capability
+    ) -> protocol.ExecuteContext:
+        return protocol.ExecuteContext(
+            query=self.query.query,
+            args=self.query.args,
+            kwargs=self.query.kwargs,
+            reg=self.cache.codecs_registry,
+            qc=self.cache.query_cache,
+            output_format=self.query_options.output_format,
+            expect_one=self.query_options.expect_one,
+            required_one=self.query_options.required_one,
+            allow_capabilities=allow_capabilities,
+            state=self.state.as_dict() if self.state else None,
+        )
+
 
 class ExecuteContext(typing.NamedTuple):
     query: QueryWithArgs
     cache: QueryCache
     state: typing.Optional[options.State]
+
+    def lower(
+        self, *, allow_capabilities: enums.Capability
+    ) -> protocol.ExecuteContext:
+        return protocol.ExecuteContext(
+            query=self.query.query,
+            args=self.query.args,
+            kwargs=self.query.kwargs,
+            reg=self.cache.codecs_registry,
+            qc=self.cache.query_cache,
+            output_format=protocol.OutputFormat.NONE,
+            allow_capabilities=allow_capabilities,
+            state=self.state.as_dict() if self.state else None,
+        )
 
 
 @dataclasses.dataclass

--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -49,7 +49,7 @@ class QueryWithArgs(typing.NamedTuple):
 
 class QueryCache(typing.NamedTuple):
     codecs_registry: protocol.CodecsRegistry
-    query_cache: protocol.QueryCodecsCache
+    query_cache: protocol.LRUMapping
 
 
 class QueryOptions(typing.NamedTuple):

--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -31,6 +31,7 @@ from .protocol import protocol
 
 
 BaseConnection_T = typing.TypeVar('BaseConnection_T', bound='BaseConnection')
+QUERY_CACHE_SIZE = 1000
 
 
 class BaseConnection(metaclass=abc.ABCMeta):
@@ -430,7 +431,7 @@ class BasePoolImpl(abc.ABC):
         self._connection_factory = connection_factory
         self._connect_args = connect_args
         self._codecs_registry = protocol.CodecsRegistry()
-        self._query_cache = protocol.QueryCodecsCache()
+        self._query_cache = protocol.LRUMapping(maxsize=QUERY_CACHE_SIZE)
 
         if max_concurrency is not None and max_concurrency <= 0:
             raise ValueError(
@@ -527,7 +528,7 @@ class BasePoolImpl(abc.ABC):
         connect_kwargs["dsn"] = dsn
         self._connect_args = connect_kwargs
         self._codecs_registry = protocol.CodecsRegistry()
-        self._query_cache = protocol.QueryCodecsCache()
+        self._query_cache = protocol.LRUMapping(maxsize=QUERY_CACHE_SIZE)
         self._working_addr = None
         self._working_config = None
         self._working_params = None

--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -183,17 +183,7 @@ class BaseConnection(metaclass=abc.ABCMeta):
             )
         else:
             await self._protocol.execute(
-                query=execute_context.query.query,
-                args=execute_context.query.args,
-                kwargs=execute_context.query.kwargs,
-                reg=execute_context.cache.codecs_registry,
-                qc=execute_context.cache.query_cache,
-                output_format=protocol.OutputFormat.NONE,
-                allow_capabilities=enums.Capability.ALL,
-                state=(
-                    execute_context.state.as_dict()
-                    if execute_context.state else None
-                ),
+                execute_context.lower(allow_capabilities=enums.Capability.ALL)
             )
 
     def is_in_transaction(self) -> bool:
@@ -211,56 +201,31 @@ class BaseConnection(metaclass=abc.ABCMeta):
             await self.connect()
 
         reconnect = False
-        capabilities = None
         i = 0
-        args = dict(
-            query=query_context.query.query,
-            args=query_context.query.args,
-            kwargs=query_context.query.kwargs,
-            reg=query_context.cache.codecs_registry,
-            qc=query_context.cache.query_cache,
-            output_format=query_context.query_options.output_format,
-            expect_one=query_context.query_options.expect_one,
-            required_one=query_context.query_options.required_one,
-        )
         if self._protocol.is_legacy:
-            args["allow_capabilities"] = enums.Capability.LEGACY_EXECUTE
+            allow_capabilities = enums.Capability.LEGACY_EXECUTE
         else:
-            args["allow_capabilities"] = enums.Capability.EXECUTE
-            if query_context.state is not None:
-                args["state"] = query_context.state.as_dict()
+            allow_capabilities = enums.Capability.EXECUTE
+        ctx = query_context.lower(allow_capabilities=allow_capabilities)
         while True:
             i += 1
             try:
                 if reconnect:
                     await self.connect(single_attempt=True)
                 if self._protocol.is_legacy:
-                    return await self._protocol.legacy_execute_anonymous(
-                        **args
-                    )
+                    return await self._protocol.legacy_execute_anonymous(ctx)
                 else:
-                    return await self._protocol.query(**args)
+                    return await self._protocol.query(ctx)
             except errors.EdgeDBError as e:
                 if query_context.retry_options is None:
                     raise
                 if not e.has_tag(errors.SHOULD_RETRY):
                     raise e
-                if capabilities is None:
-                    cache_item = query_context.cache.query_cache.get(
-                        query_context.query.query,
-                        query_context.query_options.output_format,
-                        implicit_limit=0,
-                        inline_typenames=False,
-                        inline_typeids=False,
-                        expect_one=query_context.query_options.expect_one,
-                    )
-                    if cache_item is not None:
-                        _, _, _, capabilities = cache_item
                 # A query is read-only if it has no capabilities i.e.
                 # capabilities == 0. Read-only queries are safe to retry.
                 # Explicit transaction conflicts as well.
                 if (
-                    capabilities != 0
+                    ctx.capabilities != 0
                     and not isinstance(e, errors.TransactionConflictError)
                 ):
                     raise e
@@ -281,17 +246,9 @@ class BaseConnection(metaclass=abc.ABCMeta):
             )
         else:
             await self._protocol.execute(
-                query=execute_context.query.query,
-                args=execute_context.query.args,
-                kwargs=execute_context.query.kwargs,
-                reg=execute_context.cache.codecs_registry,
-                qc=execute_context.cache.query_cache,
-                output_format=protocol.OutputFormat.NONE,
-                allow_capabilities=enums.Capability.EXECUTE,
-                state=(
-                    execute_context.state.as_dict()
-                    if execute_context.state else None
-                ),
+                execute_context.lower(
+                    allow_capabilities=enums.Capability.EXECUTE
+                )
             )
 
     async def describe(

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -67,21 +67,6 @@ cdef enum AuthenticationStatuses:
     AUTH_SASL_FINAL = 12
 
 
-cdef class QueryCodecsCache:
-
-    cdef:
-        LRUMapping queries
-
-    cdef get(
-        self, str query, OutputFormat output_format,
-        int implicit_limit, bint inline_typenames, bint inline_typeids,
-        bint expect_one)
-    cdef set(self, str query, OutputFormat output_format,
-             int implicit_limit, bint inline_typenames, bint inline_typeids,
-             bint expect_one, bytes cardinality,
-             BaseCodec in_type, BaseCodec out_type, int capabilities)
-
-
 cdef class ExecuteContext:
     cdef:
         # Input arguments
@@ -89,7 +74,7 @@ cdef class ExecuteContext:
         object args
         object kwargs
         CodecsRegistry reg
-        QueryCodecsCache qc
+        LRUMapping qc
         OutputFormat output_format
         bint expect_one
         bint required_one

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -137,7 +137,7 @@ cdef class SansIOProtocol:
     cdef parse_data_messages(self, BaseCodec out_dc, result)
     cdef parse_sync_message(self)
     cdef parse_command_complete_message(self)
-    cdef parse_describe_type_message(self, CodecsRegistry reg)
+    cdef parse_describe_type_message(self, ExecuteContext ctx)
     cdef parse_describe_state_message(self)
     cdef parse_type_data(self, CodecsRegistry reg)
     cdef _amend_parse_error(

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -74,7 +74,7 @@ cdef class QueryCodecsCache:
 
     cdef set(self, str query, OutputFormat output_format,
              int implicit_limit, bint inline_typenames, bint inline_typeids,
-             bint expect_one, bint has_na_cardinality,
+             bint expect_one, bytes cardinality,
              BaseCodec in_type, BaseCodec out_type, int capabilities)
 
 

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -101,6 +101,8 @@ cdef class ExecuteContext:
         BaseCodec out_dc
         readonly uint64_t capabilities
 
+    cdef inline bint has_na_cardinality(self)
+
 
 cdef class SansIOProtocol:
 

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -78,6 +78,30 @@ cdef class QueryCodecsCache:
              BaseCodec in_type, BaseCodec out_type, int capabilities)
 
 
+cdef class ExecuteContext:
+    cdef:
+        # Input arguments
+        str query
+        object args
+        object kwargs
+        CodecsRegistry reg
+        QueryCodecsCache qc
+        OutputFormat output_format
+        bint expect_one
+        bint required_one
+        int implicit_limit
+        bint inline_typenames
+        bint inline_typeids
+        uint64_t allow_capabilities
+        object state
+
+        # Contextual variables
+        bytes cardinality
+        BaseCodec in_dc
+        BaseCodec out_dc
+        readonly uint64_t capabilities
+
+
 cdef class SansIOProtocol:
 
     cdef:

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -165,17 +165,7 @@ cdef class SansIOProtocol:
 
     cdef ensure_connected(self)
 
-    cdef WriteBuffer encode_parse_params(
-        self,
-        str query,
-        object output_format,
-        bint expect_one,
-        int implicit_limit,
-        bint inline_typenames,
-        bint inline_typeids,
-        uint64_t allow_capabilities,
-        object state,
-    )
+    cdef WriteBuffer encode_parse_params(self, ExecuteContext ctx)
 
 
 include "protocol_v0.pxd"

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -72,6 +72,10 @@ cdef class QueryCodecsCache:
     cdef:
         LRUMapping queries
 
+    cdef get(
+        self, str query, OutputFormat output_format,
+        int implicit_limit, bint inline_typenames, bint inline_typeids,
+        bint expect_one)
     cdef set(self, str query, OutputFormat output_format,
              int implicit_limit, bint inline_typenames, bint inline_typeids,
              bint expect_one, bytes cardinality,
@@ -102,6 +106,7 @@ cdef class ExecuteContext:
         readonly uint64_t capabilities
 
     cdef inline bint has_na_cardinality(self)
+    cdef bint load_from_cache(self)
 
 
 cdef class SansIOProtocol:

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -107,6 +107,7 @@ cdef class ExecuteContext:
 
     cdef inline bint has_na_cardinality(self)
     cdef bint load_from_cache(self)
+    cdef inline store_to_cache(self)
 
 
 cdef class SansIOProtocol:

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -186,6 +186,20 @@ cdef class ExecuteContext:
             self.cardinality, self.in_dc, self.out_dc, self.capabilities = rv
             return True
 
+    cdef inline store_to_cache(self):
+        self.qc.set(
+            self.query,
+            self.output_format,
+            self.implicit_limit,
+            self.inline_typenames,
+            self.inline_typeids,
+            self.expect_one,
+            self.cardinality,
+            self.in_dc,
+            self.out_dc,
+            self.capabilities,
+        )
+
 
 cdef class SansIOProtocol:
 
@@ -412,16 +426,7 @@ cdef class SansIOProtocol:
                 if mtype == STMT_DATA_DESC_MSG:
                     # our in/out type spec is out-dated
                     self.parse_describe_type_message(ctx)
-
-                    qc.set(
-                        query,
-                        output_format,
-                        implicit_limit,
-                        inline_typenames,
-                        inline_typeids,
-                        expect_one,
-                        ctx.has_na_cardinality(),
-                        ctx.in_dc, ctx.out_dc, ctx.capabilities)
+                    ctx.store_to_cache()
                     in_dc = ctx.in_dc
                     out_dc = ctx.out_dc
 
@@ -539,22 +544,11 @@ cdef class SansIOProtocol:
             out_dc = <BaseCodec>parsed[2]
             capabilities = parsed[3]
 
-            qc.set(
-                query,
-                output_format,
-                implicit_limit,
-                inline_typenames,
-                inline_typeids,
-                expect_one,
-                cardinality,
-                in_dc,
-                out_dc,
-                capabilities,
-            )
             ctx.cardinality = cardinality
             ctx.capabilities = capabilities
             ctx.in_dc = in_dc
             ctx.out_dc = out_dc
+            ctx.store_to_cache()
 
         return await self._execute(ctx)
 

--- a/edgedb/protocol/protocol.pyx
+++ b/edgedb/protocol/protocol.pyx
@@ -114,7 +114,7 @@ cdef class QueryCodecsCache:
     cdef set(
         self, str query, OutputFormat output_format,
         int implicit_limit, bint inline_typenames, bint inline_typeids,
-        bint expect_one, bint has_na_cardinality,
+        bint expect_one, bytes cardinality,
         BaseCodec in_type, BaseCodec out_type, int capabilities,
     ):
         key = (
@@ -128,7 +128,7 @@ cdef class QueryCodecsCache:
         assert in_type is not None
         assert out_type is not None
         self.queries[key] = (
-            has_na_cardinality, in_type, out_type, capabilities
+            cardinality, in_type, out_type, capabilities
         )
 
 
@@ -405,7 +405,7 @@ cdef class SansIOProtocol:
                         inline_typenames,
                         inline_typeids,
                         expect_one,
-                        new_cardinality == CARDINALITY_NOT_APPLICABLE,
+                        new_cardinality,
                         in_dc, out_dc, capabilities)
 
                 elif mtype == STATE_DATA_DESC_MSG:
@@ -501,6 +501,7 @@ cdef class SansIOProtocol:
         cdef:
             BaseCodec in_dc
             BaseCodec out_dc
+            bytes cardinality
 
         self.ensure_connected()
         self.reset_status()
@@ -538,7 +539,7 @@ cdef class SansIOProtocol:
                 state=state,
             )
 
-            has_na_cardinality = parsed[0] == CARDINALITY_NOT_APPLICABLE
+            cardinality = parsed[0]
             in_dc = <BaseCodec>parsed[1]
             out_dc = <BaseCodec>parsed[2]
             capabilities = parsed[3]
@@ -550,7 +551,7 @@ cdef class SansIOProtocol:
                 inline_typenames,
                 inline_typeids,
                 expect_one,
-                has_na_cardinality,
+                cardinality,
                 in_dc,
                 out_dc,
                 capabilities,

--- a/edgedb/protocol/protocol_v0.pyx
+++ b/edgedb/protocol/protocol_v0.pyx
@@ -238,7 +238,6 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
             object args = ctx.args
             object kwargs = ctx.kwargs
             CodecsRegistry reg = ctx.reg
-            QueryCodecsCache qc = ctx.qc
             OutputFormat output_format = ctx.output_format
             bint expect_one = ctx.expect_one
             bint required_one = ctx.required_one
@@ -355,7 +354,6 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
             object args = ctx.args
             object kwargs = ctx.kwargs
             CodecsRegistry reg = ctx.reg
-            QueryCodecsCache qc = ctx.qc
             OutputFormat output_format = ctx.output_format
             bint expect_one = ctx.expect_one
             bint required_one = ctx.required_one

--- a/edgedb/protocol/protocol_v0.pyx
+++ b/edgedb/protocol/protocol_v0.pyx
@@ -294,7 +294,7 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
                         inline_typenames,
                         inline_typeids,
                         expect_one,
-                        new_cardinality == CARDINALITY_NOT_APPLICABLE,
+                        new_cardinality,
                         in_dc, out_dc, capabilities)
                     re_exec = True
 
@@ -412,7 +412,7 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
                 inline_typenames,
                 inline_typeids,
                 expect_one,
-                cardinality == CARDINALITY_NOT_APPLICABLE,
+                cardinality,
                 in_dc,
                 out_dc,
                 capabilities,
@@ -421,11 +421,11 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
             ret = await self._legacy_execute(in_dc, out_dc, args, kwargs)
 
         else:
-            has_na_cardinality = codecs[0]
+            cardinality = codecs[0]
             in_dc = <BaseCodec>codecs[1]
             out_dc = <BaseCodec>codecs[2]
 
-            if required_one and has_na_cardinality:
+            if required_one and cardinality == CARDINALITY_NOT_APPLICABLE:
                 methname = _QUERY_SINGLE_METHOD[required_one][output_format]
                 raise errors.InterfaceError(
                     f'query cannot be executed with {methname}() as it '

--- a/edgedb/protocol/protocol_v0.pyx
+++ b/edgedb/protocol/protocol_v0.pyx
@@ -285,19 +285,11 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
                     if capabilities is not None:
                         capabilities = int.from_bytes(capabilities, 'big')
 
-                    qc.set(
-                        query,
-                        output_format,
-                        implicit_limit,
-                        inline_typenames,
-                        inline_typeids,
-                        expect_one,
-                        new_cardinality,
-                        in_dc, out_dc, capabilities)
                     ctx.cardinality = new_cardinality
                     ctx.in_dc = in_dc
                     ctx.out_dc = out_dc
                     ctx.capabilities = capabilities
+                    ctx.store_to_cache()
 
                     re_exec = True
 
@@ -399,22 +391,11 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
                 if capabilities is not None:
                     capabilities = int.from_bytes(capabilities, 'big')
 
-            qc.set(
-                query,
-                output_format,
-                implicit_limit,
-                inline_typenames,
-                inline_typeids,
-                expect_one,
-                cardinality,
-                in_dc,
-                out_dc,
-                capabilities,
-                )
             ctx.cardinality = cardinality
             ctx.in_dc = in_dc
             ctx.out_dc = out_dc
             ctx.capabilities = capabilities
+            ctx.store_to_cache()
 
             ret = await self._legacy_execute(in_dc, out_dc, args, kwargs)
 

--- a/edgedb/protocol/protocol_v0.pyx
+++ b/edgedb/protocol/protocol_v0.pyx
@@ -434,7 +434,7 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
             ctx.out_dc = out_dc
             ctx.capabilities = codecs[3]
 
-            if required_one and cardinality == CARDINALITY_NOT_APPLICABLE:
+            if required_one and ctx.has_na_cardinality():
                 methname = _QUERY_SINGLE_METHOD[required_one][output_format]
                 raise errors.InterfaceError(
                     f'query cannot be executed with {methname}() as it '

--- a/edgedb/protocol/protocol_v0.pyx
+++ b/edgedb/protocol/protocol_v0.pyx
@@ -375,14 +375,7 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
         self.ensure_connected()
         self.reset_status()
 
-        codecs = qc.get(
-            query,
-            output_format,
-            implicit_limit,
-            inline_typenames,
-            inline_typeids,
-            expect_one)
-        if codecs is None:
+        if not ctx.load_from_cache():
             codecs = await self._legacy_parse(
                 query,
                 reg=reg,
@@ -426,14 +419,6 @@ cdef class SansIOProtocolBackwardsCompatible(SansIOProtocol):
             ret = await self._legacy_execute(in_dc, out_dc, args, kwargs)
 
         else:
-            cardinality = codecs[0]
-            in_dc = <BaseCodec>codecs[1]
-            out_dc = <BaseCodec>codecs[2]
-            ctx.cardinality = cardinality
-            ctx.in_dc = in_dc
-            ctx.out_dc = out_dc
-            ctx.capabilities = codecs[3]
-
             if required_one and ctx.has_na_cardinality():
                 methname = _QUERY_SINGLE_METHOD[required_one][output_format]
                 raise errors.InterfaceError(

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -102,7 +102,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
     def test_sync_transaction_exclusive(self):
         for tx in self.client.transaction():
             with tx:
-                query = "select sys::_sleep(0.01)"
+                query = "select sys::_sleep(0.5)"
                 with ThreadPoolExecutor(max_workers=2) as executor:
                     f1 = executor.submit(tx.execute, query)
                     f2 = executor.submit(tx.execute, query)


### PR DESCRIPTION
So that we can pass out the parsed capabilities to control retries. This also allows further code optimization.

Fixes #493 