### PR TITLE
Use result of pydantic_dataclass, will silence linters

### DIFF
--- a/edgedb/codegen/generator.py
+++ b/edgedb/codegen/generator.py
@@ -107,7 +107,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []\
 """

--- a/tests/codegen/test-project1/select_optional_json_async_edgeql.py.assert
+++ b/tests/codegen/test-project1/select_optional_json_async_edgeql.py.assert
@@ -20,7 +20,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []
 

--- a/tests/codegen/test-project2/object/link_prop_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/object/link_prop_async_edgeql.py.assert
@@ -21,7 +21,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []
 

--- a/tests/codegen/test-project2/object/select_objects_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/object/select_objects_async_edgeql.py.assert
@@ -20,7 +20,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []
 

--- a/tests/codegen/test-project2/parpkg/select_args_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/parpkg/select_args_async_edgeql.py.assert
@@ -20,7 +20,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []
 

--- a/tests/codegen/test-project2/parpkg/subpkg/my_query_async_edgeql.py.assert
+++ b/tests/codegen/test-project2/parpkg/subpkg/my_query_async_edgeql.py.assert
@@ -26,7 +26,7 @@ class NoPydanticValidation:
     def __get_validators__(cls):
         # Pydantic 1.x
         from pydantic.dataclasses import dataclass as pydantic_dataclass
-        pydantic_dataclass(cls)
+        _ = pydantic_dataclass(cls)
         cls.__pydantic_model__.__get_validators__ = lambda: []
         return []
 


### PR DESCRIPTION
This fix will silence some linters warning about unused results.