### PR TITLE
Bump cibuildwheel to 2.19.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==2.12.3
+      - run: pip install cibuildwheel==2.19.1
       - id: set-matrix
         # Cannot test on Musl distros yet.
         run: |
@@ -130,7 +130,7 @@ jobs:
     - name: Install EdgeDB
       uses: edgedb/setup-edgedb@v1
 
-    - uses: pypa/cibuildwheel@v2.12.3
+    - uses: pypa/cibuildwheel@v2.19.1
       with:
           only: ${{ matrix.only }}
       env:


### PR DESCRIPTION
This adds Python 3.12 to the build matrix.

[Sample run](https://github.com/edgedb/edgedb-python/actions/runs/9574583424)