### PR TITLE
ci: give repo write permission to the publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,8 @@ jobs:
   publish:
     needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix issue in release: https://github.com/edgedb/edgedb-python/actions/runs/9584452538/job/26430421964#step:7:23

Copied from edgedb/homebrew-tap#6