### PR TITLE
edgedb-python 2.0.1

### DIFF
--- a/.github/workflows/install-edgedb.sh
+++ b/.github/workflows/install-edgedb.sh
@@ -17,7 +17,7 @@ else
     adduser -s /bin/bash -D edgedb
 fi
 
-su -l edgedb -c "edgedb server install"
+su -l edgedb -c "edgedb server install --version ${EDGEDB_SERVER_VERSION}"
 ln -s $(su -l edgedb -c "edgedb server info --latest --bin-path") \
     "/usr/bin/edgedb-server"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
 
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
+      EDGEDB_SERVER_VERSION: 5
 
     steps:
     - uses: actions/checkout@v3
@@ -140,17 +141,17 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_ALL_LINUX: >
-          .github/workflows/install-edgedb.sh
+          EDGEDB_SERVER_VERSION=${{ env.EDGEDB_SERVER_VERSION }} .github/workflows/install-edgedb.sh
         CIBW_TEST_EXTRAS: "test"
         CIBW_TEST_COMMAND: >
-          python {project}/tests/__init__.py
+          EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX=.assert${{ env.EDGEDB_SERVER_VERSION }} python {project}/tests/__init__.py
         CIBW_TEST_COMMAND_WINDOWS: >
-          python {project}\tests\__init__.py
+          set EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX=.assert${{ env.EDGEDB_SERVER_VERSION }} && python {project}\tests\__init__.py
         CIBW_TEST_COMMAND_LINUX: >
           PY=`which python`
           && CODEGEN=`which edgedb-py`
           && chmod -R go+rX "$(dirname $(dirname $(dirname $PY)))"
-          && su -l edgedb -c "EDGEDB_PYTHON_TEST_CODEGEN_CMD=$CODEGEN $PY {project}/tests/__init__.py"
+          && su -l edgedb -c "EDGEDB_PYTHON_TEST_CODEGEN_CMD=$CODEGEN EDGEDB_TEST_CODEGEN_ASSERT_SUFFIX=.assert${{ env.EDGEDB_SERVER_VERSION }} $PY {project}/tests/__init__.py"
 
     - uses: actions/upload-artifact@v3
       with:

--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
Fixes
=====

* Allow running release workflow manually
  (by @elprans in 7141d3ca)

* Fix build on GCC 14 (#510)
  (by @fantix in 45cf86a9 for #510)

* Fix codegen due to internal API change (#509)
  (by @fantix in 640f9ed2 for #506)

* #515
  (by @elprans in 5305fa8d)