### PR TITLE
edgedb-python 1.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - "master"
       - "ci"
-      - "[0-9]+.[0-9x]+*"
+      - "release/[0-9]+.x"
+      - "release/[0-9]+.[0-9]+.x"
     paths:
       - "edgedb/_version.py"
 
@@ -80,9 +81,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==2.12.3
+      - run: pip install cibuildwheel==2.19.2
       - id: set-matrix
         # Cannot test on Musl distros yet.
+        env:
+          CIBW_SKIP: "cp312-*"
         run: |
           MATRIX_INCLUDE=$(
             {
@@ -130,7 +133,7 @@ jobs:
     - name: Install EdgeDB
       uses: edgedb/setup-edgedb@v1
 
-    - uses: pypa/cibuildwheel@v2.12.3
+    - uses: pypa/cibuildwheel@v2.19.2
       with:
           only: ${{ matrix.only }}
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,8 @@ jobs:
   publish:
     needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3

--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,6 @@ setuptools.setup(
             include_dirs=INCLUDE_DIRS),
     ],
     cmdclass={'build_ext': build_ext},
-    test_suite='tests.suite',
     python_requires=">=3.7",
     install_requires=[
         'typing-extensions>=3.10.0; python_version < "3.8.0"',

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1107,7 +1107,7 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
         ''')
 
     async def test_transaction_state(self):
-        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to id"):
+        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to.*id"):
             async for tx in self.client.transaction():
                 async with tx:
                     await tx.execute('''

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -868,7 +868,7 @@ class TestSyncQuery(tb.SyncQueryTestCase):
             self.client.execute('start transaction')
 
     def test_transaction_state(self):
-        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to id"):
+        with self.assertRaisesRegex(edgedb.QueryError, "cannot assign to.*id"):
             for tx in self.client.transaction():
                 with tx:
                     tx.execute('''


### PR DESCRIPTION
- Remove deprecated `test_suite` kwarg from `setuptools.setup()`
- edgedb-python v1.6.1
