### PR TITLE
Remove deprecated `test_suite` kwarg from `setuptools.setup()`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,6 @@ setuptools.setup(
             include_dirs=INCLUDE_DIRS),
     ],
     cmdclass={'build_ext': build_ext},
-    test_suite='tests.suite',
     python_requires=">=3.8",
     install_requires=[
         'certifi>=2021.5.30; platform_system == "Windows"',


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/4519
