### PR TITLE
Add a rudimentary warning system

### DIFF
--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -64,6 +64,7 @@ class QueryContext(typing.NamedTuple):
     query_options: QueryOptions
     retry_options: typing.Optional[options.RetryOptions]
     state: typing.Optional[options.State]
+    warning_handler: options.WarningHandler
 
     def lower(
         self, *, allow_capabilities: enums.Capability
@@ -86,6 +87,7 @@ class ExecuteContext(typing.NamedTuple):
     query: QueryWithArgs
     cache: QueryCache
     state: typing.Optional[options.State]
+    warning_handler: options.WarningHandler
 
     def lower(
         self, *, allow_capabilities: enums.Capability
@@ -181,6 +183,10 @@ class BaseReadOnlyExecutor(abc.ABC):
     def _get_state(self) -> options.State:
         ...
 
+    @abc.abstractmethod
+    def _get_warning_handler(self) -> options.WarningHandler:
+        ...
+
 
 class ReadOnlyExecutor(BaseReadOnlyExecutor):
     """Subclasses can execute *at least* read-only queries"""
@@ -198,6 +204,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handlerr=self._get_warning_handler(),
         ))
 
     def query_single(
@@ -209,6 +216,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     def query_required_single(self, query: str, *args, **kwargs) -> typing.Any:
@@ -218,6 +226,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     def query_json(self, query: str, *args, **kwargs) -> str:
@@ -227,6 +236,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     def query_single_json(self, query: str, *args, **kwargs) -> str:
@@ -236,6 +246,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     def query_required_single_json(self, query: str, *args, **kwargs) -> str:
@@ -245,6 +256,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     @abc.abstractmethod
@@ -256,6 +268,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query=QueryWithArgs(commands, args, kwargs),
             cache=self._get_query_cache(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
 
@@ -281,6 +294,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     async def query_single(self, query: str, *args, **kwargs) -> typing.Any:
@@ -290,6 +304,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     async def query_required_single(
@@ -304,6 +319,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     async def query_json(self, query: str, *args, **kwargs) -> str:
@@ -313,6 +329,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     async def query_single_json(self, query: str, *args, **kwargs) -> str:
@@ -322,6 +339,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     async def query_required_single_json(
@@ -336,6 +354,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_required_single_json_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     @abc.abstractmethod
@@ -347,6 +366,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
             query=QueryWithArgs(commands, args, kwargs),
             cache=self._get_query_cache(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
 

--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -204,7 +204,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
             query_options=_query_opts,
             retry_options=self._get_retry_options(),
             state=self._get_state(),
-            warning_handlerr=self._get_warning_handler(),
+            warning_handler=self._get_warning_handler(),
         ))
 
     def query_single(

--- a/edgedb/options.py
+++ b/edgedb/options.py
@@ -24,6 +24,7 @@ WarningHandler = typing.Callable[
     typing.Any,
 ]
 
+
 def raise_warnings(warnings, res):
     if (
         len(warnings) > 1

--- a/edgedb/options.py
+++ b/edgedb/options.py
@@ -30,7 +30,7 @@ def raise_warnings(warnings, res):
         len(warnings) > 1
         and sys.version_info >= (3, 11)
     ):
-        raise ExceptionGroup(
+        raise ExceptionGroup(  # noqa
             "Query produced warnings", warnings
         )
     else:

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -89,6 +89,7 @@ cdef class ExecuteContext:
         readonly BaseCodec in_dc
         readonly BaseCodec out_dc
         readonly uint64_t capabilities
+        readonly tuple warnings
 
     cdef inline bint has_na_cardinality(self)
     cdef bint load_from_cache(self)
@@ -142,6 +143,7 @@ cdef class SansIOProtocol:
     )
 
     cdef inline ignore_headers(self)
+    cdef inline dict read_headers(self)
     cdef dict parse_error_headers(self)
 
     cdef parse_error_message(self)

--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -185,6 +185,9 @@ class BaseTransaction:
     def _get_state(self) -> options.State:
         return self._client._get_state()
 
+    def _get_warning_handler(self) -> options.WarningHandler:
+        return self._client._get_warning_handler()
+
     async def _query(self, query_context: abstract.QueryContext):
         await self._ensure_transaction()
         return await self._connection.raw_query(query_context)

--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -201,6 +201,7 @@ class BaseTransaction:
             query=abstract.QueryWithArgs(query, (), {}),
             cache=self._get_query_cache(),
             state=self._get_state(),
+            warning_handler=self._get_warning_handler(),
         ))
 
 

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1035,6 +1035,7 @@ class TestAsyncQuery(tb.AsyncQueryTestCase):
                 ),
                 retry_options=None,
                 state=None,
+                warning_handler=lambda _ex, _: None,
             )
         )
         self.assertEqual(

--- a/tests/test_sync_query.py
+++ b/tests/test_sync_query.py
@@ -792,6 +792,7 @@ class TestSyncQuery(tb.SyncQueryTestCase):
                     ),
                     retry_options=None,
                     state=None,
+                    warning_handler=lambda _ex, _: None,
                 )
             )
         )


### PR DESCRIPTION
In this initial iteration of it, warnings are encoded in JSON as a
header for CommandDataDescription.

A `warning_handler` field is added to `Options`, and it is invoked if
any warnings occured. We provide two built-in functions:
`log_warnings` and `raise_warnings`. The default is `log_warnings`.