### PR TITLE
Prepare for 3.13 upgrade

### DIFF
--- a/edgedb/datatypes/object.c
+++ b/edgedb/datatypes/object.c
@@ -152,9 +152,9 @@ object_dealloc(EdgeObject *o)
     }
     Py_CLEAR(o->desc);
     o->cached_hash = -1;
-    Py_TRASHCAN_SAFE_BEGIN(o)
+    Py_TRASHCAN_BEGIN(o, object_dealloc);
     EDGE_DEALLOC_WITH_FREELIST(EDGE_OBJECT, EdgeObject, o);
-    Py_TRASHCAN_SAFE_END(o)
+    Py_TRASHCAN_END(o);
 }
 
 

--- a/edgedb/protocol/protocol.pxd
+++ b/edgedb/protocol/protocol.pxd
@@ -41,10 +41,10 @@ ctypedef object (*decode_row_method)(BaseCodec, FRBuffer *buf)
 
 
 cpdef enum OutputFormat:
-    BINARY = b'b'
-    JSON = b'j'
-    JSON_ELEMENTS = b'J'
-    NONE = b'n'
+    BINARY = 98  # b'b'
+    JSON = 106  # b'j'
+    JSON_ELEMENTS = 74  # b'J'
+    NONE = 110  # b'n'
 
 
 cdef enum TransactionStatus:


### PR DESCRIPTION
New versions of cython have some regression in the handling of enums
that breaks us.  Fix it.  We have to do this separately from the
cython version upgrade because apparently we need to do the
edgedb-server cython upgrade at the same time. We'd like to just do
server first, but some test code on the server cimports edgedb-python,
and so we need to land the fix in edgedb-python before we can be ready
to upgrade the server.

This is of course a further argument in @mmastrac's favor about moving
towards a monorepo.