### PR TITLE
edgedb-python 2.2.0a

### DIFF
--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '2.1.0'
+__version__ = '2.2.0a1'


### PR DESCRIPTION
Releasing an alpha so we can bump edgedb-server to it easily now, even
though there will be temporarily mismatching Cython versions.