### PR TITLE
Add package alias with new name

### DIFF
--- a/gel/__init__.py
+++ b/gel/__init__.py
@@ -1,0 +1,22 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# flake8: noqa
+
+from edgedb import *

--- a/setup.py
+++ b/setup.py
@@ -295,10 +295,13 @@ setuptools.setup(
     url='https://github.com/edgedb/edgedb-python',
     license='Apache License, Version 2.0',
     packages=setuptools.find_packages(),
-    provides=['edgedb'],
+    provides=['edgedb', 'gel'],
     zip_safe=False,
     include_package_data=True,
-    package_data={'edgedb': ['py.typed']},
+    package_data={
+        'edgedb': ['py.typed'],
+        'gel': ['py.typed'],
+    },
     ext_modules=[
         distutils_extension.Extension(
             "edgedb.pgproto.pgproto",

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -23,10 +23,8 @@ import queue
 import unittest.mock
 from concurrent import futures
 
-import edgedb
+import gel
 from edgedb import _testbase as tb
-from edgedb import errors
-from edgedb import RetryOptions
 
 
 class Barrier:
@@ -82,7 +80,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                         };
                     ''')
                     1 / 0
-        with self.assertRaises(edgedb.NoDataError):
+        with self.assertRaises(gel.NoDataError):
             self.client.query_required_single('''
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_02'
@@ -109,9 +107,9 @@ class TestSyncRetry(tb.SyncQueryTestCase):
 
         self.addCleanup(cleanup)
 
-        _start.side_effect = errors.BackendUnavailableError()
+        _start.side_effect = gel.BackendUnavailableError()
 
-        with self.assertRaises(errors.BackendUnavailableError):
+        with self.assertRaises(gel.BackendUnavailableError):
             for tx in self.client.transaction():
                 with tx:
                     tx.execute('''
@@ -119,7 +117,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
                             name := 'counter_retry_begin'
                         };
                     ''')
-        with self.assertRaises(edgedb.NoDataError):
+        with self.assertRaises(gel.NoDataError):
             self.client.query_required_single('''
                 SELECT test::Counter
                 FILTER .name = 'counter_retry_begin'
@@ -134,7 +132,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
 
         def recover_after_first_error(*_, **__):
             patcher.stop()
-            raise errors.BackendUnavailableError()
+            raise gel.BackendUnavailableError()
 
         _start.side_effect = recover_after_first_error
         call_count = _start.call_count
@@ -156,16 +154,16 @@ class TestSyncRetry(tb.SyncQueryTestCase):
         self.execute_conflict('counter2')
 
     def test_sync_conflict_no_retry(self):
-        with self.assertRaises(edgedb.TransactionSerializationError):
+        with self.assertRaises(gel.TransactionSerializationError):
             self.execute_conflict(
                 'counter3',
-                RetryOptions(attempts=1, backoff=edgedb.default_backoff)
+                gel.RetryOptions(attempts=1, backoff=gel.default_backoff)
             )
 
     def execute_conflict(self, name='counter2', options=None):
         con_args = self.get_connect_args().copy()
         con_args.update(database=self.get_database_name())
-        client2 = edgedb.create_client(**con_args)
+        client2 = gel.create_client(**con_args)
         self.addCleanup(client2.close)
 
         barrier = Barrier(2)
@@ -243,13 +241,13 @@ class TestSyncRetry(tb.SyncQueryTestCase):
             for tx in self.client.transaction():
                 tx.start()
 
-        with self.assertRaisesRegex(edgedb.InterfaceError,
+        with self.assertRaisesRegex(gel.InterfaceError,
                                     r'.*Use `with transaction:`'):
             for tx in self.client.transaction():
                 tx.execute("SELECT 123")
 
         with self.assertRaisesRegex(
-            edgedb.InterfaceError,
+            gel.InterfaceError,
             r"already in a `with` block",
         ):
             for tx in self.client.transaction():


### PR DESCRIPTION
Add a `gel` alias that does `import *` from `edgedb`.

Note that this will *not* provide any submodules.
Doing `from gel import errors` won't work.

But we also never documented anything internal, and it will all keep
working with an `edgedb` import, so nothing will break.

If we feel strongly about providing all the internal modules under the
`gel` name also, we have options, but as far as I can tell they are
all annoying in some way:
 - Generate a parallel tree of modules under `gel` that all do `import *`
   from an appropriate `edgedb` module. This is kind of ugly and also
   we need to regenerate when anything changes.
 - Something involving hooking the python import system. I think this
   would work but also I think involves modifying global python interpreter
   state when `gel` is imported, which is dodgy.

I'd probably go with option 1 if we care, but not caring seems fine?