### PR TITLE
Make the edgedb proxy package work a little better for typecheckers

### DIFF
--- a/edgedb/__init__.py
+++ b/edgedb/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel import *  # noqa
 import gel as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb']

--- a/edgedb/_taskgroup.py
+++ b/edgedb/_taskgroup.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel._taskgroup import *  # noqa
 import gel._taskgroup as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb._taskgroup']

--- a/edgedb/_version.py
+++ b/edgedb/_version.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel._version import *  # noqa
 import gel._version as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb._version']

--- a/edgedb/abstract.py
+++ b/edgedb/abstract.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.abstract import *  # noqa
 import gel.abstract as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.abstract']

--- a/edgedb/ai/__init__.py
+++ b/edgedb/ai/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.ai import *  # noqa
 import gel.ai as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.ai']

--- a/edgedb/ai/core.py
+++ b/edgedb/ai/core.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.ai.core import *  # noqa
 import gel.ai.core as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.ai.core']

--- a/edgedb/ai/types.py
+++ b/edgedb/ai/types.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.ai.types import *  # noqa
 import gel.ai.types as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.ai.types']

--- a/edgedb/asyncio_client.py
+++ b/edgedb/asyncio_client.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.asyncio_client import *  # noqa
 import gel.asyncio_client as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.asyncio_client']

--- a/edgedb/base_client.py
+++ b/edgedb/base_client.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.base_client import *  # noqa
 import gel.base_client as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.base_client']

--- a/edgedb/blocking_client.py
+++ b/edgedb/blocking_client.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.blocking_client import *  # noqa
 import gel.blocking_client as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.blocking_client']

--- a/edgedb/codegen.py
+++ b/edgedb/codegen.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.codegen import *  # noqa
 import gel.codegen as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.codegen']

--- a/edgedb/color.py
+++ b/edgedb/color.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.color import *  # noqa
 import gel.color as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.color']

--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.con_utils import *  # noqa
 import gel.con_utils as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.con_utils']

--- a/edgedb/credentials.py
+++ b/edgedb/credentials.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.credentials import *  # noqa
 import gel.credentials as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.credentials']

--- a/edgedb/datatypes/__init__.py
+++ b/edgedb/datatypes/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.datatypes import *  # noqa
 import gel.datatypes as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.datatypes']

--- a/edgedb/datatypes/datatypes.py
+++ b/edgedb/datatypes/datatypes.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.datatypes.datatypes import *  # noqa
 import gel.datatypes.datatypes as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.datatypes.datatypes']

--- a/edgedb/datatypes/range.py
+++ b/edgedb/datatypes/range.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.datatypes.range import *  # noqa
 import gel.datatypes.range as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.datatypes.range']

--- a/edgedb/describe.py
+++ b/edgedb/describe.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.describe import *  # noqa
 import gel.describe as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.describe']

--- a/edgedb/enums.py
+++ b/edgedb/enums.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.enums import *  # noqa
 import gel.enums as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.enums']

--- a/edgedb/errors/__init__.py
+++ b/edgedb/errors/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.errors import *  # noqa
 import gel.errors as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.errors']

--- a/edgedb/errors/_base.py
+++ b/edgedb/errors/_base.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.errors._base import *  # noqa
 import gel.errors._base as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.errors._base']

--- a/edgedb/errors/tags.py
+++ b/edgedb/errors/tags.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.errors.tags import *  # noqa
 import gel.errors.tags as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.errors.tags']

--- a/edgedb/introspect.py
+++ b/edgedb/introspect.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.introspect import *  # noqa
 import gel.introspect as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.introspect']

--- a/edgedb/options.py
+++ b/edgedb/options.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.options import *  # noqa
 import gel.options as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.options']

--- a/edgedb/pgproto/__init__.py
+++ b/edgedb/pgproto/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.pgproto import *  # noqa
 import gel.pgproto as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.pgproto']

--- a/edgedb/pgproto/pgproto.py
+++ b/edgedb/pgproto/pgproto.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.pgproto.pgproto import *  # noqa
 import gel.pgproto.pgproto as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.pgproto.pgproto']

--- a/edgedb/pgproto/types.py
+++ b/edgedb/pgproto/types.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.pgproto.types import *  # noqa
 import gel.pgproto.types as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.pgproto.types']

--- a/edgedb/platform.py
+++ b/edgedb/platform.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.platform import *  # noqa
 import gel.platform as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.platform']

--- a/edgedb/protocol/__init__.py
+++ b/edgedb/protocol/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.protocol import *  # noqa
 import gel.protocol as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.protocol']

--- a/edgedb/protocol/asyncio_proto.py
+++ b/edgedb/protocol/asyncio_proto.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.protocol.asyncio_proto import *  # noqa
 import gel.protocol.asyncio_proto as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.protocol.asyncio_proto']

--- a/edgedb/protocol/blocking_proto.py
+++ b/edgedb/protocol/blocking_proto.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.protocol.blocking_proto import *  # noqa
 import gel.protocol.blocking_proto as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.protocol.blocking_proto']

--- a/edgedb/protocol/protocol.py
+++ b/edgedb/protocol/protocol.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.protocol.protocol import *  # noqa
 import gel.protocol.protocol as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.protocol.protocol']

--- a/edgedb/scram/__init__.py
+++ b/edgedb/scram/__init__.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.scram import *  # noqa
 import gel.scram as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.scram']

--- a/edgedb/scram/saslprep.py
+++ b/edgedb/scram/saslprep.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.scram.saslprep import *  # noqa
 import gel.scram.saslprep as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.scram.saslprep']

--- a/edgedb/transaction.py
+++ b/edgedb/transaction.py
@@ -1,4 +1,7 @@
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from gel.transaction import *  # noqa
 import gel.transaction as _mod
 import sys as _sys
 _cur = _sys.modules['edgedb.transaction']

--- a/gel/__init__.py
+++ b/gel/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "EnumValue",
     "Executor",
     "IsolationLevel",
+    "MultiRange",
     "NamedTuple",
     "Object",
     "Range",

--- a/gel/abstract.py
+++ b/gel/abstract.py
@@ -33,6 +33,7 @@ __all__ = (
     "QueryOptions",
     "QueryContext",
     "Executor",
+    "ExecuteContext",
     "AsyncIOExecutor",
     "ReadOnlyExecutor",
     "AsyncIOReadOnlyExecutor",

--- a/tools/make_import_shims.py
+++ b/tools/make_import_shims.py
@@ -22,6 +22,9 @@ def main():
         with open(fname, 'w') as f:
             f.write(f'''\
 # Auto-generated shim
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from {mod} import *  # noqa
 import {mod} as _mod
 import sys as _sys
 _cur = _sys.modules['{nmod}']


### PR DESCRIPTION
We don't expose all the hidden stuff but we still do an import *.