### PR TITLE
gel-python 3.0.0b7

### DIFF
--- a/gel/_version.py
+++ b/gel/_version.py
@@ -28,4 +28,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '3.0.0b6'
+__version__ = '3.0.0b7'


### PR DESCRIPTION
b6 failed for annoying reasons. I could probably
try to do b6 again but it doesn't really matter if
we "waste" some beta versions.
Note this is trying to release a *gel* package