### PR TITLE
Update gel-orm generators.

### DIFF
--- a/gel/orm/introspection.py
+++ b/gel/orm/introspection.py
@@ -31,7 +31,7 @@ select ObjectType {
             ),
             target: {name},
         },
-    } filter .name != '__type__',
+    } filter .name != '__type__' and not exists .expr,
     properties: {
         name,
         readonly,
@@ -42,7 +42,7 @@ select ObjectType {
             filter .name = 'std::exclusive'
         ),
         target: {name},
-    },
+    } filter not exists .expr,
     backlinks := <array<str>>[],
 }
 filter

--- a/tests/dbsetup/base.edgeql
+++ b/tests/dbsetup/base.edgeql
@@ -42,3 +42,13 @@ insert Post {
     author := assert_single((select User filter .name = 'Elsa')),
     body := '*magic stuff*',
 };
+
+insert AssortedScalars {
+    name:= 'hello world',
+    vals := ['brown', 'fox'],
+    bstr := b'word\x00\x0b',
+    time := <cal::local_time>'20:13:45.678',
+    date:= <cal::local_date>'2025-01-26',
+    ts:=<datetime>'2025-01-26T20:13:45+00:00',
+    lts:=<cal::local_datetime>'2025-01-26T20:13:45',
+};

--- a/tests/dbsetup/base.esdl
+++ b/tests/dbsetup/base.esdl
@@ -15,9 +15,23 @@ type GameSession {
     };
 }
 
-type User extending Named;
+type User extending Named {
+    # test computed backlink
+    groups := .<users[is UserGroup];
+}
 
 type Post {
     required body: str;
     required link author: User;
+}
+
+type AssortedScalars {
+    required name: str;
+    vals: array<str>;
+
+    date: cal::local_date;
+    time: cal::local_time;
+    ts: datetime;
+    lts: cal::local_datetime;
+    bstr: bytes;
 }

--- a/tests/dbsetup/sqlmodel.edgeql
+++ b/tests/dbsetup/sqlmodel.edgeql
@@ -59,3 +59,13 @@ update HasLinkPropsB
 set {
     children += (select Child{@b := 'world'} filter .num = 1)
 };
+
+insert AssortedScalars {
+    name:= 'hello world',
+    vals := ['brown', 'fox'],
+    bstr := b'word\x00\x0b',
+    time := <cal::local_time>'20:13:45.678',
+    date:= <cal::local_date>'2025-01-26',
+    ts:=<datetime>'2025-01-26T20:13:45+00:00',
+    lts:=<cal::local_datetime>'2025-01-26T20:13:45',
+};

--- a/tests/dbsetup/sqlmodel.esdl
+++ b/tests/dbsetup/sqlmodel.esdl
@@ -39,3 +39,14 @@ type HasLinkPropsB {
         property b: str;
     }
 }
+
+type AssortedScalars {
+    required name: str;
+    vals: array<str>;
+
+    date: cal::local_date;
+    time: cal::local_time;
+    ts: datetime;
+    lts: cal::local_datetime;
+    bstr: bytes;
+}

--- a/tests/test_sqlmodel_basic.py
+++ b/tests/test_sqlmodel_basic.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import datetime as dt
 import os
 import uuid
 import unittest
@@ -323,6 +324,34 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             }
         )
 
+    def test_sqlmodel_read_models_08(self):
+        # test arrays, bytes and various date/time scalars
+
+        res = self.sess.exec(
+            select(self.sm.AssortedScalars)
+        ).one()
+
+        self.assertEqual(res.name, 'hello world')
+        self.assertEqual(res.bstr, b'word\x00\x0b')
+        self.assertEqual(
+            res.time,
+            dt.time(20, 13, 45, 678_000),
+        )
+        self.assertEqual(
+            res.date,
+            dt.date(2025, 1, 26),
+        )
+        # time zone aware
+        self.assertEqual(
+            res.ts,
+            dt.datetime.fromisoformat('2025-01-26T20:13:45+00:00'),
+        )
+        # naive datetime
+        self.assertEqual(
+            res.lts,
+            dt.datetime.fromisoformat('2025-01-26T20:13:45'),
+        )
+
     def test_sqlmodel_create_models_01(self):
         vals = self.sess.exec(
             select(self.sm.User).where(
@@ -590,6 +619,52 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
 
         post = self.sess.get(self.sm.Post, post_id)
         self.assertEqual(post.author.name, 'Zoe')
+
+    def test_sqlmodel_update_models_05(self):
+        # test arrays, bytes and various date/time scalars
+        #
+        # For the purpose of sending data creating and updating a model are
+        # both testing accurate data transfer.
+
+        res = self.sess.exec(
+            select(self.sm.AssortedScalars)
+        ).one()
+
+        res.name = 'New Name'
+        # res.vals.append('jumped')
+        res.bstr = b'\x01success\x02'
+        res.time = dt.time(8, 23, 54, 999_000)
+        res.date = dt.date(2020, 2, 14)
+        res.ts = res.ts - dt.timedelta(days=6)
+        res.lts = res.lts + dt.timedelta(days=6)
+
+        self.sess.add(res)
+        self.sess.flush()
+
+        upd = self.sess.exec(
+            select(self.sm.AssortedScalars)
+        ).one()
+
+        self.assertEqual(upd.name, 'New Name')
+        self.assertEqual(upd.bstr, b'\x01success\x02')
+        self.assertEqual(
+            upd.time,
+            dt.time(8, 23, 54, 999_000),
+        )
+        self.assertEqual(
+            upd.date,
+            dt.date(2020, 2, 14),
+        )
+        # time zone aware
+        self.assertEqual(
+            upd.ts,
+            dt.datetime.fromisoformat('2025-01-20T20:13:45+00:00'),
+        )
+        # naive datetime
+        self.assertEqual(
+            upd.lts,
+            dt.datetime.fromisoformat('2025-02-01T20:13:45'),
+        )
 
     def test_sqlmodel_linkprops_01(self):
         val = self.sess.exec(select(self.sm.HasLinkPropsA)).one()


### PR DESCRIPTION
Make generated models sorted by name so that the output is stable and does not change when the schema does not change.
Expose arrays as valid scalars for SQLAlchemy and Django. 
Don't attempt to reflect computeds because we don't have then in SQL. 
Reformat to avoid long lines.