### PR TITLE
Update

### DIFF
--- a/gel/orm/django/generator.py
+++ b/gel/orm/django/generator.py
@@ -85,7 +85,7 @@ class ModelClass(object):
         return self.meta['db_table'].strip("'")
 
     def get_backlink_name(self, name, srcname):
-        return self.backlink_renames.get(name, f'back_to_{srcname}')
+        return f'_{name}_{srcname}'
 
 
 class ModelGenerator(FilePrinter):

--- a/gel/orm/sqla.py
+++ b/gel/orm/sqla.py
@@ -282,10 +282,7 @@ class ModelGenerator(FilePrinter):
                     bklink = source_link
                 else:
                     src = modules[mod]['object_types'][source_name]
-                    bklink = src['backlink_renames'].get(
-                        source_link,
-                        f'back_to_{source_name}',
-                    )
+                    bklink = f'_{source_link}_{source_name}'
 
                 self.write(
                     f'{lname}: orm.Mapped[{pyname}] = '
@@ -418,7 +415,7 @@ class ModelGenerator(FilePrinter):
         tmod, target = get_mod_and_name(spec['target']['name'])
         source = modules[mod]['object_types'][parent]
         cardinality = spec['cardinality']
-        bklink = source['backlink_renames'].get(name, f'back_to_{parent}')
+        bklink = f'_{name}_{parent}'
 
         if spec.get('has_link_object'):
             # intermediate object will have the actual source and target

--- a/gel/orm/sqlmodel.py
+++ b/gel/orm/sqlmodel.py
@@ -317,10 +317,7 @@ class ModelGenerator(FilePrinter):
                     bklink = source_link
                 else:
                     src = modules[mod]['object_types'][source_name]
-                    bklink = src['backlink_renames'].get(
-                        source_link,
-                        f'back_to_{source_name}',
-                    )
+                    bklink = f'_{source_link}_{source_name}'
 
                 self.write(
                     f'{lname}: {pyname} = sm.Relationship(')
@@ -452,7 +449,7 @@ class ModelGenerator(FilePrinter):
         tmod, target = get_mod_and_name(spec['target']['name'])
         source = modules[mod]['object_types'][parent]
         cardinality = spec['cardinality']
-        bklink = source['backlink_renames'].get(name, f'back_to_{parent}')
+        bklink = f'_{name}_{parent}'
 
         if tmod != 'default':
             warnings.warn(

--- a/tests/test_django_basic.py
+++ b/tests/test_django_basic.py
@@ -30,6 +30,7 @@ else:
     NO_ORM = False
 
 from gel import _testbase as tb
+from gel.orm.django import generator
 
 
 class TestDjangoBasic(tb.DjangoTestCase):
@@ -550,4 +551,36 @@ class TestDjangoBasic(tb.DjangoTestCase):
         self.assertEqual(
             upd.ts,
             dt.datetime.fromisoformat('2025-01-20T20:13:45+00:00'),
+        )
+
+    def test_django_sorting(self):
+        # Test the natural sorting function used for ordering fields, etc.
+
+        unsorted = {
+            'zoo': 1,
+            'apple': 1,
+            'potato': 1,
+            'grape10': 1,
+            'grape1': 1,
+            'grape5': 1,
+            'grape2': 1,
+            'grape20': 1,
+            'grape25': 1,
+            'grape12': 1,
+        }
+
+        self.assertEqual(
+            list(sorted(unsorted.items(), key=generator.field_name_sort)),
+            [
+                ('apple', 1),
+                ('grape1', 1),
+                ('grape2', 1),
+                ('grape5', 1),
+                ('grape10', 1),
+                ('grape12', 1),
+                ('grape20', 1),
+                ('grape25', 1),
+                ('potato', 1),
+                ('zoo', 1),
+            ],
         )

--- a/tests/test_sqla_basic.py
+++ b/tests/test_sqla_basic.py
@@ -30,6 +30,7 @@ else:
     NO_ORM = False
 
 from gel import _testbase as tb
+from gel.orm import sqla
 
 
 class TestSQLABasic(tb.SQLATestCase):
@@ -648,4 +649,36 @@ class TestSQLABasic(tb.SQLATestCase):
         self.assertEqual(
             upd.lts,
             dt.datetime.fromisoformat('2025-02-01T20:13:45'),
+        )
+
+    def test_sqla_sorting(self):
+        # Test the natural sorting function used for ordering fields, etc.
+
+        unsorted = [
+            {'name': 'zoo'},
+            {'name': 'apple'},
+            {'name': 'potato'},
+            {'name': 'grape10'},
+            {'name': 'grape1'},
+            {'name': 'grape5'},
+            {'name': 'grape2'},
+            {'name': 'grape20'},
+            {'name': 'grape25'},
+            {'name': 'grape12'},
+        ]
+
+        self.assertEqual(
+            list(sorted(unsorted, key=sqla.field_name_sort)),
+            [
+                {'name': 'apple'},
+                {'name': 'grape1'},
+                {'name': 'grape2'},
+                {'name': 'grape5'},
+                {'name': 'grape10'},
+                {'name': 'grape12'},
+                {'name': 'grape20'},
+                {'name': 'grape25'},
+                {'name': 'potato'},
+                {'name': 'zoo'},
+            ],
         )

--- a/tests/test_sqla_features.py
+++ b/tests/test_sqla_features.py
@@ -224,24 +224,21 @@ class TestSQLAFeatures(tb.SQLATestCase):
 
         # only one link from Bar 123 to foo
         self.assertEqual(
-            [obj.n for obj in foo.follow_foo_back_to_Bar],
+            [obj.n for obj in foo._foo_Bar],
             [123],
         )
         # only one link from Who 456 to oof
         self.assertEqual(
-            [obj.x for obj in oof.follow_foo_back_to_Who],
+            [obj.x for obj in oof._foo_Who],
             [456],
         )
 
         # foo is linked via `many_foo` from both Bar and Who
         self.assertEqual(
-            [obj.n for obj in foo.follow_many_foo_back_to_Bar],
+            [obj.n for obj in foo._many_foo_Bar],
             [123],
         )
         self.assertEqual(
-            [
-                (obj.note, obj.source.x)
-                for obj in foo.follow_many_foo_back_to_Who
-            ],
+            [(obj.note, obj.source.x) for obj in foo._many_foo_Who],
             [('just one', 456)],
         )

--- a/tests/test_sqlmodel_basic.py
+++ b/tests/test_sqlmodel_basic.py
@@ -29,6 +29,7 @@ else:
     NO_ORM = False
 
 from gel import _testbase as tb
+from gel.orm import sqlmodel as sqlm
 
 
 class TestSQLModelBasic(tb.SQLModelTestCase):
@@ -751,4 +752,36 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         self.assertEqual(
             {(c.b, c.target.num) for c in val.children},
             {('world', 1)},
+        )
+
+    def test_sqlmodel_sorting(self):
+        # Test the natural sorting function used for ordering fields, etc.
+
+        unsorted = [
+            {'name': 'zoo'},
+            {'name': 'apple'},
+            {'name': 'potato'},
+            {'name': 'grape10'},
+            {'name': 'grape1'},
+            {'name': 'grape5'},
+            {'name': 'grape2'},
+            {'name': 'grape20'},
+            {'name': 'grape25'},
+            {'name': 'grape12'},
+        ]
+
+        self.assertEqual(
+            list(sorted(unsorted, key=sqlm.field_name_sort)),
+            [
+                {'name': 'apple'},
+                {'name': 'grape1'},
+                {'name': 'grape2'},
+                {'name': 'grape5'},
+                {'name': 'grape10'},
+                {'name': 'grape12'},
+                {'name': 'grape20'},
+                {'name': 'grape25'},
+                {'name': 'potato'},
+                {'name': 'zoo'},
+            ],
         )

--- a/tests/test_sqlmodel_basic.py
+++ b/tests/test_sqlmodel_basic.py
@@ -115,7 +115,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             select(self.sm.User).order_by('name')
         )
         vals = [
-            (u.name, {p.body for p in u.back_to_Post})
+            (u.name, {p.body for p in u._author_Post})
             for u in res
         ]
         self.assertEqual(
@@ -150,11 +150,11 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         # prefetch via backlink
         res = self.sess.exec(
             select(self.sm.User).join(
-                self.sm.User.back_to_Post, isouter=True
+                self.sm.User._author_Post, isouter=True
             ).order_by(self.sm.Post.body)
         )
         vals = {
-            (u.name, tuple(p.body for p in u.back_to_Post))
+            (u.name, tuple(p.body for p in u._author_Post))
             for u in res
         }
         self.assertEqual(
@@ -188,7 +188,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         # use backlink
         res = self.sess.exec(select(self.sm.User))
         vals = {
-            (u.name, tuple(g.num for g in u.back_to_GameSession))
+            (u.name, tuple(g.num for g in u._players_GameSession))
             for u in res
         }
         self.assertEqual(
@@ -226,11 +226,11 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         # prefetch via backlink
         res = self.sess.exec(
             select(self.sm.User).join(
-                self.sm.User.back_to_GameSession, isouter=True,
+                self.sm.User._players_GameSession, isouter=True,
             )
         )
         vals = {
-            (u.name, tuple(g.num for g in u.back_to_GameSession))
+            (u.name, tuple(g.num for g in u._players_GameSession))
             for u in res
         }
         self.assertEqual(
@@ -267,7 +267,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             select(self.sm.User).order_by('name')
         )
         vals = [
-            (u.name, {g.name for g in u.back_to_UserGroup})
+            (u.name, {g.name for g in u._users_UserGroup})
             for u in res
         ]
         self.assertEqual(
@@ -306,11 +306,11 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         # prefetch via backlink
         res = self.sess.exec(
             select(self.sm.User).join(
-                self.sm.User.back_to_UserGroup, isouter=True,
+                self.sm.User._users_UserGroup, isouter=True,
             )
         )
         vals = {
-            (u.name, tuple(sorted(g.name for g in u.back_to_UserGroup)))
+            (u.name, tuple(sorted(g.name for g in u._users_UserGroup)))
             for u in res
         }
         self.assertEqual(
@@ -390,7 +390,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             ).one()
 
             self.assertEqual(user.name, name)
-            self.assertEqual(user.back_to_UserGroup[0].name, 'cyan')
+            self.assertEqual(user._users_UserGroup[0].name, 'cyan')
             self.assertIsInstance(user.id, uuid.UUID)
 
     def test_sqlmodel_create_models_03(self):
@@ -398,8 +398,8 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         user1 = self.sm.User(name='Xander')
         cyan = self.sm.UserGroup(name='cyan')
 
-        user0.back_to_UserGroup.append(cyan)
-        user1.back_to_UserGroup.append(cyan)
+        user0._users_UserGroup.append(cyan)
+        user1._users_UserGroup.append(cyan)
 
         self.sess.add(cyan)
         self.sess.flush()
@@ -410,7 +410,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             ).one()
 
             self.assertEqual(user.name, name)
-            self.assertEqual(user.back_to_UserGroup[0].name, 'cyan')
+            self.assertEqual(user._users_UserGroup[0].name, 'cyan')
             self.assertIsInstance(user.id, uuid.UUID)
 
     def test_sqlmodel_create_models_04(self):
@@ -565,13 +565,13 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
         self.sess.flush()
 
         self.assertEqual(
-            {g.name for g in user.back_to_UserGroup},
+            {g.name for g in user._users_UserGroup},
             {'red', 'blue'},
         )
         self.assertEqual(user.name, 'Yvonne')
         self.assertIsInstance(user.id, uuid.UUID)
 
-        group = [g for g in user.back_to_UserGroup if g.name == 'red'][0]
+        group = [g for g in user._users_UserGroup if g.name == 'red'][0]
         self.assertEqual(
             {u.name for u in group.users},
             {'Alice', 'Billie', 'Cameron', 'Dana', 'Yvonne'},
@@ -585,7 +585,7 @@ class TestSQLModelBasic(tb.SQLModelTestCase):
             select(self.sm.User).filter_by(name='Zoe')
         ).one()
         # Replace the author or a post
-        post = user0.back_to_Post[0]
+        post = user0._author_Post[0]
         body = post.body
         post.author = user1
 


### PR DESCRIPTION
Some more updates to ORM generators.

Mainly this update is about changing the backlink naming scheme to `_<link>_<Type>` format across all of the Python ORM generators.

Add some tests.