### PR TITLE
Retry calls to `execute` as well as to `query`

### DIFF
--- a/gel/abstract.py
+++ b/gel/abstract.py
@@ -92,6 +92,7 @@ class QueryContext(typing.NamedTuple):
 class ExecuteContext(typing.NamedTuple):
     query: QueryWithArgs
     cache: QueryCache
+    retry_options: typing.Optional[options.RetryOptions]
     state: typing.Optional[options.State]
     warning_handler: options.WarningHandler
     annotations: typing.Dict[str, str]
@@ -187,8 +188,9 @@ class BaseReadOnlyExecutor(abc.ABC):
     def _get_query_cache(self) -> QueryCache:
         ...
 
+    @abc.abstractmethod
     def _get_retry_options(self) -> typing.Optional[options.RetryOptions]:
-        return None
+        ...
 
     @abc.abstractmethod
     def _get_state(self) -> options.State:
@@ -303,6 +305,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
         self._execute(ExecuteContext(
             query=QueryWithArgs(commands, args, kwargs),
             cache=self._get_query_cache(),
+            retry_options=self._get_retry_options(),
             state=self._get_state(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
@@ -317,6 +320,7 @@ class ReadOnlyExecutor(BaseReadOnlyExecutor):
                 input_language=protocol.InputLanguage.SQL,
             ),
             cache=self._get_query_cache(),
+            retry_options=self._get_retry_options(),
             state=self._get_state(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
@@ -438,6 +442,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
         await self._execute(ExecuteContext(
             query=QueryWithArgs(commands, args, kwargs),
             cache=self._get_query_cache(),
+            retry_options=self._get_retry_options(),
             state=self._get_state(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
@@ -452,6 +457,7 @@ class AsyncIOReadOnlyExecutor(BaseReadOnlyExecutor):
                 input_language=protocol.InputLanguage.SQL,
             ),
             cache=self._get_query_cache(),
+            retry_options=self._get_retry_options(),
             state=self._get_state(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),

--- a/gel/transaction.py
+++ b/gel/transaction.py
@@ -184,6 +184,9 @@ class BaseTransaction:
     def _get_query_cache(self) -> abstract.QueryCache:
         return self._client._get_query_cache()
 
+    def _get_retry_options(self) -> typing.Optional[options.RetryOptions]:
+        return None
+
     def _get_state(self) -> options.State:
         return self._client._get_state()
 
@@ -206,6 +209,7 @@ class BaseTransaction:
             query=abstract.QueryWithArgs(query, (), {}),
             cache=self._get_query_cache(),
             state=self._get_state(),
+            retry_options=self._get_retry_options(),
             warning_handler=self._get_warning_handler(),
             annotations=self._get_annotations(),
         ))

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -20,7 +20,6 @@ import asyncio
 
 import logging
 import unittest.mock
-import sys
 
 import edgedb
 from edgedb import errors
@@ -263,10 +262,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
 
         excs = [e for e in results if isinstance(e, BaseException)]
         if excs:
-            if sys.version_info >= (3, 11) and len(excs) > 1:
-                raise ExceptionGroup('multiple failures', excs)
-            else:
-                raise excs[0]
+            raise excs[0]
         val = await client1.query_single('''
             select (select test::Counter filter .name = <str>$name).value
         ''', name=name)

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -20,6 +20,7 @@ import asyncio
 
 import logging
 import unittest.mock
+import sys
 
 import edgedb
 from edgedb import errors
@@ -57,10 +58,6 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
                 SET default := 0;
             };
         };
-    '''
-
-    TEARDOWN = '''
-        DROP TYPE test::Counter;
     '''
 
     async def test_async_retry_01(self):
@@ -205,6 +202,76 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
 
         self.assertEqual(set(results), {1, 2})
         self.assertEqual(iterations, 3)
+
+    async def test_async_retry_conflict_nontx_01(self):
+        await self.execute_nontx_conflict(
+            'counter_nontx_01',
+            lambda client, *args, **kwargs: client.query(*args, **kwargs)
+        )
+
+    async def test_async_retry_conflict_nontx_02(self):
+        await self.execute_nontx_conflict(
+            'counter_nontx_02',
+            lambda client, *args, **kwargs: client.execute(*args, **kwargs)
+        )
+
+    async def execute_nontx_conflict(self, name, func):
+        # Test retries on conflicts in a non-tx setting.  We do this
+        # by having conflicting upserts that are made long-running by
+        # adding a sys::_sleep call.
+        #
+        # Unlike for the tx ones, we don't assert that a retry
+        # actually was necessary, since that feels fragile in a
+        # timing-based test like this.
+
+        client1 = self.client
+        client2 = self.make_test_client(database=self.get_database_name())
+        self.addCleanup(client2.aclose)
+
+        await client1.query("SELECT 1")
+        await client2.query("SELECT 1")
+
+        query = '''
+            SELECT (
+                INSERT test::Counter {
+                    name := <str>$name,
+                    value := 1,
+                } UNLESS CONFLICT ON .name
+                ELSE (
+                    UPDATE test::Counter
+                    SET { value := .value + 1 }
+                )
+            ).value
+            ORDER BY sys::_sleep(<int64>$sleep)
+            THEN <int64>$nonce
+        '''
+
+        await func(client1, query, name=name, sleep=0, nonce=0)
+
+        task1 = asyncio.create_task(
+            func(client1, query, name=name, sleep=5, nonce=1)
+        )
+        task2 = asyncio.create_task(
+            func(client2, query, name=name, sleep=5, nonce=2)
+        )
+
+        results = await asyncio.wait_for(asyncio.gather(
+            task1,
+            task2,
+            return_exceptions=True,
+        ), 20)
+
+        excs = [e for e in results if isinstance(e, BaseException)]
+        if excs:
+            if sys.version_info >= (3, 11) and len(excs) > 1:
+                raise ExceptionGroup('multiple failures', excs)
+            else:
+                raise excs[0]
+        val = await client1.query_single('''
+            select (select test::Counter filter .name = <str>$name).value
+        ''', name=name)
+
+        self.assertEqual(val, 3)
 
     async def test_async_transaction_interface_errors(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
In the distant past, execute was quite different than query (execute
couldn't take arguments and query could not include multiple
commands), so it maybe made sense to have different retry behaviors.

Now, execute and query are basically identical except for whether data
is returned, and so I don't think there is any reason why they
shouldn't both do retries.

(I modeled the implementation after how I did this in the edgedb test
suite's hacked up client: edgedb/edgedb#8249)