### PR TITLE
models: Fix use of implicit casts in overloads and generality sorting

### DIFF
--- a/gel/_internal/_reflection/__init__.py
+++ b/gel/_internal/_reflection/__init__.py
@@ -29,6 +29,7 @@ from ._callables import (
     CallableParamKey,
     CallableParamTypeMap,
     CallableSignature,
+    compare_callable_generality,
 )
 
 from ._functions import (
@@ -62,6 +63,7 @@ from ._types import (
     ScalarType,
     TupleType,
     Type,
+    compare_type_generality,
     fetch_types,
     is_array_type,
     is_link,
@@ -115,6 +117,8 @@ __all__ = (
     "Type",
     "TypeKind",
     "TypeModifier",
+    "compare_callable_generality",
+    "compare_type_generality",
     "fetch_branch_state",
     "fetch_casts",
     "fetch_functions",

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -3395,7 +3395,7 @@ class TestModelGenerator(tb.ModelTestCase):
             "tuple<a:std::str, b:tuple<c:std::int64, d:std::str>>",
         )
 
-    @tb.typecheck_xfail
+    @tb.typecheck
     def test_modelgen_function_overloads_01(self):
         """Test basic function overloads with different parameter types"""
         from models import default
@@ -3537,7 +3537,7 @@ class TestModelGenerator(tb.ModelTestCase):
         )
         self.assertEqual(result_str_int, "str+int: value 200")
 
-    @tb.typecheck_xfail
+    @tb.typecheck
     def test_modelgen_function_overloads_with_python_values(self):
         """Test that function overloads work with regular Python values"""
         from models import default


### PR DESCRIPTION
Take cast distance into account when spreading implicit casts in
overloads.  Also, implement a more precise generality sorting of
overloads to take inheritance distance into account where types are
unrelated, and add a special case for floats vs ints as type checkers
consider the latter to be more general than the former (per PEP 3141)
