### PR TITLE
Stop storing UNSET_UUID in models; don't use it as default for 'id'

### DIFF
--- a/gel/_internal/_qbmodel/_pydantic/_fields.py
+++ b/gel/_internal/_qbmodel/_pydantic/_fields.py
@@ -40,8 +40,6 @@ from ._pdlist import ProxyDistinctList
 
 from . import _utils as _pydantic_utils
 
-from gel._internal._unsetid import UNSET_UUID
-
 if TYPE_CHECKING:
     from typing_extensions import Never
     from collections.abc import Sequence
@@ -236,7 +234,7 @@ IdProperty = TypeAliasType(
     "IdProperty",
     Annotated[
         Property[_ST_co, _BT_co],
-        pydantic.Field(default=UNSET_UUID, init=False, frozen=True),
+        pydantic.Field(init=False, frozen=True),
         _abstract.PointerInfo(
             computed=True,
             readonly=True,

--- a/gel/_internal/_qbmodel/_pydantic/_pdlist.py
+++ b/gel/_internal/_qbmodel/_pydantic/_pdlist.py
@@ -29,9 +29,6 @@ from gel._internal import _typing_parametric as parametric
 
 from ._models import GelModel, ProxyModel
 
-from gel._internal._unsetid import UNSET_UUID
-
-
 _BMT_co = TypeVar("_BMT_co", bound=GelModel, covariant=True)
 """Base model type"""
 
@@ -144,7 +141,7 @@ class ProxyDistinctList(
                         f"a different set of link properties"
                     )
 
-            if obj.id is UNSET_UUID:
+            if obj.__gel_new__:
                 self._unhashables[id(proxy)] = proxy
             else:
                 self._set.add(proxy)


### PR DESCRIPTION
Instead of initializing `.id` for new models to UNSET_UUID we now don't set it at all. Instead of returning UNSET_UUID, new models will simply throw an `AttributeError`. Which is ultimately a less surprising behavior than getting a weird flavor of UUID type that they can't do anything with in most cases (but would be pretty bad if it somehow surfaces in an unexpected place).

We also no longer use it as a default for GelModel's `id` field. This fixes warnings in pydantic, when it's failing to serialize UNSET_UUID default value for rendering in JSON schemas.

GelModel gets a new internal attribute `__gel_new__`. When set to `True` it meand the model hasn't yet been persisted. `__gel_commit__` flips it to `False`.