### PR TITLE
models: Remove deprecated uses of pydantic FieldInfo

### DIFF
--- a/gel/_internal/_qbmodel/_abstract/__init__.py
+++ b/gel/_internal/_qbmodel/_abstract/__init__.py
@@ -15,7 +15,6 @@ from ._base import (
     DefaultValue,
     GelType,
     GelTypeMeta,
-    PointerInfo,
 )
 
 from ._descriptors import (
@@ -145,7 +144,6 @@ __all__ = (
     "OptionalPointerDescriptor",
     "OptionalPropertyDescriptor",
     "PointerDescriptor",
-    "PointerInfo",
     "PropertyDescriptor",
     "ProxyDistinctList",
     "PyConstType",

--- a/gel/_internal/_qbmodel/_abstract/_base.py
+++ b/gel/_internal/_qbmodel/_abstract/_base.py
@@ -18,12 +18,10 @@ from typing import (
 
 from typing_extensions import Self
 
-import dataclasses
 import functools
 import typing
 import weakref
 
-from gel._internal import _edgeql
 from gel._internal import _qb
 from gel._internal._xmethod import hybridmethod
 
@@ -36,16 +34,6 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class PointerInfo:
-    computed: bool = False
-    readonly: bool = False
-    has_props: bool = False
-    cardinality: _edgeql.Cardinality = _edgeql.Cardinality.One
-    annotation: type[Any] | None = None
-    kind: _edgeql.PointerKind | None = None
 
 
 if TYPE_CHECKING:

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -629,7 +629,7 @@ def make_plan(objs: Iterable[GelModel]) -> SavePlan:
                 and prop.properties
             ):
                 val = getattr(obj, prop.name, _unset)
-                if val is _unset:
+                if val is _unset or val is None:
                     continue
                 assert isinstance(val, ProxyModel)
                 lprops = val.__linkprops__


### PR DESCRIPTION
Stop using `pydantic.Field` in type aliases as that is explicitly
advised against in the Pydantic docs and is now triggering a usage
warning.  Instead, add the requisite attributes of `Field` to
`PointerInfo` and use that when augmenting fields in
`_process_pydantic_fields`.
