### PR TITLE
Use `__tname__` instead of `__tid__` for polymorphic result resolution

### DIFF
--- a/gel/_internal/_qb/_reflection.py
+++ b/gel/_internal/_qb/_reflection.py
@@ -9,7 +9,6 @@ import dataclasses
 
 if TYPE_CHECKING:
     import abc
-    import uuid
     from gel._internal import _edgeql
     from gel._internal._schemapath import SchemaPath
 
@@ -28,13 +27,11 @@ class GelPointerReflection:
 
 
 class GelReflectionProto(Protocol):
-    id: ClassVar[uuid.UUID]
     name: ClassVar[SchemaPath]
 
 
 class GelSchemaMetadata:
     class __gel_reflection__:  # noqa: N801
-        id: ClassVar[uuid.UUID]
         name: ClassVar[SchemaPath]
 
 

--- a/gel/_internal/_qbmodel/_pydantic/_models.py
+++ b/gel/_internal/_qbmodel/_pydantic/_models.py
@@ -74,7 +74,6 @@ class GelModelMeta(
         bases: tuple[type[Any], ...],
         namespace: dict[str, Any],
         *,
-        __gel_type_id__: uuid.UUID | None = None,
         __gel_shape__: str | None = None,
         __gel_root_class__: bool = False,
         **kwargs: Any,
@@ -173,8 +172,9 @@ class GelModelMeta(
                 )
                 setattr(cls, fname, desc)
 
-        if __gel_type_id__ is not None:
-            mcls.register_class(__gel_type_id__, cls)
+        reflection = cls.__gel_reflection__
+        if (tname := getattr(reflection, "name", None)) is not None:
+            mcls.__gel_class_registry__[tname] = cls
 
         cls.__gel_shape__ = __gel_shape__
 

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -966,7 +966,7 @@ class SaveExecutor:
         # Queries must be independent of each other within the same
         # ChangeBatch, so we can sort them to group queries.
         compiled.sort(
-            key=lambda x: (x[0].__gel_reflection__.id, x[1].single_query)
+            key=lambda x: (x[0].__gel_reflection__.name, x[1].single_query)
         )
 
         icomp = iter(compiled)

--- a/gel/abstract.py
+++ b/gel/abstract.py
@@ -194,6 +194,7 @@ class BaseQueryContext(Generic[_T_ql]):
             output_format=self.query_options.output_format,
             expect_one=self.query_options.expect_one,
             required_one=self.query_options.required_one,
+            inline_typenames=self.query.return_type is not None,
             allow_capabilities=allow_capabilities,
             state=self.state.as_dict() if self.state else None,
             annotations=self.annotations,

--- a/gel/protocol/codecs/object.pxd
+++ b/gel/protocol/codecs/object.pxd
@@ -26,14 +26,14 @@ cdef class ObjectCodec(BaseNamedRecordCodec):
         tuple flags
         tuple source_types
 
-        dict cached_tid_map
+        dict cached_tname_map
         tuple cached_return_type_subcodecs
         tuple cached_return_type_dlists
         object cached_return_type_proxy
         object cached_return_type
         object cached_field_origins
         object cached_orig_return_type
-        Py_ssize_t cached_tid_index
+        Py_ssize_t cached_tname_index
 
     cdef encode_args(self, WriteBuffer buf, dict obj)
 

--- a/gel/protocol/protocol.pyx
+++ b/gel/protocol/protocol.pyx
@@ -319,9 +319,6 @@ cdef class SansIOProtocol:
 
         compilation_flags = enums.CompilationFlag.INJECT_OUTPUT_OBJECT_IDS
 
-        # XXX
-        compilation_flags |= enums.CompilationFlag.INJECT_OUTPUT_TYPE_IDS
-
         if ctx.inline_typenames:
             compilation_flags |= enums.CompilationFlag.INJECT_OUTPUT_TYPE_NAMES
         if ctx.inline_typeids:


### PR DESCRIPTION
The type ids of object types in gel are not consistent between
instances. We must not hardcode them into generated code.

Fixes: #832
