### PR TITLE
Enable --cache-dir when running mypy

### DIFF
--- a/gel/_testbase.py
+++ b/gel/_testbase.py
@@ -1239,7 +1239,7 @@ class TestModel(_testbase.{base_class_name}):
                 "--config-file",
                 inifn,
                 "--cache-dir",
-                str(pathlib.Path(__file__).parent.parent / '.mypy_cache'),
+                str(pathlib.Path(__file__).parent.parent / ".mypy_cache"),
                 testfn,
             ]
 


### PR DESCRIPTION
This saves about 25s on my machine when the models haven't changed,
and maybe 7s if they have (for checking the stdlib).