### PR TITLE
Unify behavior of expressions without explict `.select()`

### DIFF
--- a/gel/_internal/_qbmodel/_abstract/_descriptors.py
+++ b/gel/_internal/_qbmodel/_abstract/_descriptors.py
@@ -183,14 +183,22 @@ class ModelFieldDescriptor(_qb.AbstractFieldDescriptor):
                 type_ = t.__gel_reflection__.name
             else:
                 type_ = ptr.type
+
+            is_link = issubclass(t, AbstractGelModel)
             metadata = _qb.Path(
                 type_=type_,
                 source=source,
                 name=self.__gel_name__,
                 is_lprop=False,
-                is_link=issubclass(t, AbstractGelModel)
+                is_link=is_link,
             )
-            return _qb.AnnotatedPath(t, metadata)
+            res = _qb.AnnotatedPath(t, metadata)
+
+            if is_link:
+                # wrap into a splat shape
+                res = _qb.Shape.splat(res)
+
+            return res
 
     def __get__(
         self,


### PR DESCRIPTION
Closes https://github.com/geldata/gel-python/issues/838

I've written a "debug log" of my thinking when fixing a sub-issue here, in the first commit of this PR.
It might be worth reading, because it shows why working on this codebase is hard.

---

We want to make the query builder API have consistent behavior in
absence of explict query shapes.

Given these three cases:

```python
default.User

default.User.posts

default.User.select(
  posts=default.User.posts
)
```

... we'd want all paths without an explict `.select` return all pointers
of the target type, not just the id.

Current behavior:
- case 1: `select User { * }`,
- case 2: `select User.posts`,
- case 3: `select User { posts }`.

---

This PR changes that to:
- case 1: `select User { * }` (unchanged),
- case 2: `select User.posts { * }`,
- case 3: `select User { posts: { * } }`.
