### PR TITLE
Fix == on arrays

### DIFF
--- a/gel/_internal/_codegen/_models/_pydantic.py
+++ b/gel/_internal/_codegen/_models/_pydantic.py
@@ -1515,8 +1515,9 @@ class BaseGeneratedModule:
             foreign_import_time = import_time
 
         if reflection.is_array_type(stype):
-            arr = self.import_name(
-                BASE_IMPL, "Array", import_time=foreign_import_time
+            arr = self.get_object(
+                SchemaPath('std', 'array'),
+                aspect=ModuleAspect.SHAPES,
             )
             elem_type = self.get_type(
                 stype.get_element_type(self._types),

--- a/tests/test_qb.py
+++ b/tests/test_qb.py
@@ -807,10 +807,6 @@ class TestQueryBuilder(tb.ModelTestCase):
         self.assertEqual(post.author.name, "Elsa")
         self.assertEqual(post.body, "*magic stuff*")
 
-    @tb.xfail('''
-        == on Array seems busted both for the typechecker and runtime
-        Issue #896
-    ''')
     def test_qb_filter_09(self):
         from models.orm import default, std
 
@@ -820,11 +816,10 @@ class TestQueryBuilder(tb.ModelTestCase):
             "*",
             players=True,
         ).filter(
-            lambda g: std.array_agg(g.players.id)
-            == std.array_agg(green.users.id)
+            lambda g: std.array_agg(g.players.order_by(id=True).id)
+            == std.array_agg(green.users.order_by(id=True).id)
         )
 
-        self.assertEqual(1, 2)
         res = self.client.get(q)
         green_res = self.client.get(green)
         self.assertEqual(res.num, 123)


### PR DESCRIPTION
Currently, doing `==` on arrays fails at runtime with
```
AttributeError: type object 'Array[models.__sharedstd__.__shapes__.std.uuid]' has no attribute '__gel_type_class__'
```
and produces a `bool` at typecheck time instead of a `type[std.bool]`.

My approach to fixing this is to replace uses of `Array` with
`std.array`, which has a `__gel_type_class__` and all the appropriate
overloadings.

When I extend this approach to other similar types, though, like
`Range`, I run into problems: the `typing_dispatch` based overloaded
constructor for range always fails when doing a
`Type.model_validate(r.model_dump())`, in part because the overloads
all seem to want want `std.bool` and won't accept real bools.

@elprans Does this seem like the right approach, and I should continue
down this path and fix any problems in the way (like those mentioned
above), or do you think I'm on the wrong track here?