### PR TITLE
Fix a bunch of issues with arrays as properties

### DIFF
--- a/gel/_internal/_qbmodel/_pydantic/_types.py
+++ b/gel/_internal/_qbmodel/_pydantic/_types.py
@@ -48,7 +48,7 @@ class Array(_abstract.Array[_T]):
     def _validate(
         cls,
         value: Any,
-    ) -> _tracked_list.DowncastingTrackedList[_T, _T]:  # XXX
+    ) -> _tracked_list.TrackedList[_T]:
         tp = cls.__gel_resolve_dlist__()
         if isinstance(value, tp):
             return value
@@ -58,9 +58,9 @@ class Array(_abstract.Array[_T]):
     @classmethod
     def __gel_resolve_dlist__(
         cls,
-    ) -> type[_tracked_list.DowncastingTrackedList[_T, _T]]:  # XXX
+    ) -> type[_tracked_list.TrackedList[_T]]:
         down = _abstract.get_py_type_from_gel_type(cls.__element_type__)
-        return _tracked_list.DowncastingTrackedList[cls.__element_type__, down]  # type: ignore [name-defined, valid-type]
+        return _tracked_list.TrackedList[down]  # type: ignore [valid-type]
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -68,15 +68,18 @@ class Array(_abstract.Array[_T]):
         source_type: Any,
         handler: pydantic.GetCoreSchemaHandler,
     ) -> pydantic_core.CoreSchema:
+        subschema = handler.generate_schema(cls.__element_type__)
+        listschema = core_schema.list_schema(subschema)
         return core_schema.json_or_python_schema(
-            json_schema=core_schema.list_schema(
-                handler.generate_schema(cls.__element_type__)
-            ),
+            json_schema=listschema,
             python_schema=core_schema.no_info_plain_validator_function(
                 cls._validate,
             ),
+            # We need to do a cast to list first, since we used
+            # TrackedList underneath instead of an actual Array...
             serialization=core_schema.plain_serializer_function_ser_schema(
                 list,
+                return_schema=listschema,
             ),
         )
 
@@ -97,9 +100,6 @@ class Tuple(_abstract.Tuple[Unpack[_Ts]]):
             items_schema=[
                 handler.generate_schema(arg) for arg in cls.__element_types__
             ],
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                tuple,
-            ),
         )
 
 

--- a/gel/_internal/_save.py
+++ b/gel/_internal/_save.py
@@ -357,9 +357,7 @@ class IDTracker(Generic[T, V]):
 
 
 def is_prop_list(val: object) -> TypeGuard[TrackedList[GelPrimitiveType]]:
-    return isinstance(
-        val, (TrackedList, DowncastingTrackedList)
-    ) and issubclass(type(val).type, GelPrimitiveType)  # type: ignore [misc]
+    return isinstance(val, (TrackedList, DowncastingTrackedList))
 
 
 def is_link_set(val: object) -> TypeGuard[LinkSet[GelModel]]:

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -1044,6 +1044,7 @@ class TestModelGeneratorMain(tb.ModelTestCase):
                 p_tuparr=True,
             ).limit(1)
         )
+        self.assertPydanticSerializes(sl)
 
         sl2 = repickle(sl)
         self.assertEqual(sl.model_dump(), sl2.model_dump())


### PR DESCRIPTION
Fix json_schema on arrays and multi properties.

Don't use DowncastingTrackedList (which I guess I will now remove in a
follow-up) because we don't want it's behavior of casting things to types
like `std.str`.

Update the CoreSchemas of arrays, multiprops, and tuples to properly use
the underlying serializers -- for array and multi prop, we want to convert
to a `list`, and then run a normal pydantic list serializer on the output
type.

Without this, multi props of arrays wouldn't convert the interior arrays
into lists (leaving them as TrackedList), which caused problems like
breaking model_dump_json.


Fixes #937